### PR TITLE
Added a pretty printer package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,48 @@
   "object": {
     "pins": [
       {
+        "package": "Algebra",
+        "repositoryURL": "https://github.com/typelift/Algebra.git",
+        "state": {
+          "branch": null,
+          "revision": "e81a20aa543dd0847897b57073a3f939c2124375",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "package": "DoctorPretty",
+        "repositoryURL": "https://github.com/bkase/DoctorPretty.git",
+        "state": {
+          "branch": null,
+          "revision": "2d0370ade8098dd1e24c08460edc1606eb81a54f",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "Operadics",
+        "repositoryURL": "https://github.com/typelift/Operadics.git",
+        "state": {
+          "branch": null,
+          "revision": "bc8cdd83868c395b7075d0db5e930842172012ec",
+          "version": "0.2.3"
+        }
+      },
+      {
         "package": "Prelude",
         "repositoryURL": "https://github.com/pointfreeco/swift-prelude.git",
         "state": {
           "branch": "d242e07",
           "revision": "d242e075fd6a07abb9bcefa70187ead2302c277d",
           "version": null
+        }
+      },
+      {
+        "package": "Swiftx",
+        "repositoryURL": "https://github.com/typelift/Swiftx.git",
+        "state": {
+          "branch": null,
+          "revision": "32cb9a833cbc69b1ee2ebad2392eca3090b7211c",
+          "version": "0.5.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,13 @@ let package = Package(
     .library(name: "CssReset", targets: ["CssReset"]),
     .library(name: "Html", targets: ["Html"]),
     .library(name: "HtmlCssSupport", targets: ["HtmlCssSupport"]),
+    .library(name: "HtmlPrettyPrint", targets: ["HtmlPrettyPrint"]),
     .library(name: "HttpPipeline", targets: ["HttpPipeline"]),
     .library(name: "HttpPipelineHtmlSupport", targets: ["HttpPipelineHtmlSupport"]),
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("d242e07")),
+    .package(url: "https://github.com/bkase/DoctorPretty.git", .exact("0.3.0")),
   ],
   targets: [
     .target(name: "ApplicativeRouter", dependencies: ["Prelude"]),
@@ -31,6 +33,9 @@ let package = Package(
 
     .target(name: "HtmlCssSupport", dependencies: ["Css", "Html"]),
     .testTarget(name: "HtmlCssSupportTests", dependencies: ["HtmlCssSupport"]),
+
+    .target(name: "HtmlPrettyPrint", dependencies: ["DoctorPretty", "Html"]),
+    .testTarget(name: "HtmlPrettyPrintTests", dependencies: ["HtmlPrettyPrint"]),
 
     .target(name: "HttpPipeline", dependencies: ["Prelude"]),
     .testTarget(name: "HttpPipelineTests", dependencies: ["HttpPipeline"]),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     .testTarget(name: "HtmlTests", dependencies: ["Html", "HtmlCssSupport"]),
 
     .target(name: "HtmlCssSupport", dependencies: ["Css", "Html"]),
-    .testTarget(name: "HtmlCssSupportTests", dependencies: ["HtmlCssSupport"]),
+    .testTarget(name: "HtmlCssSupportTests", dependencies: ["HtmlCssSupport", "HtmlPrettyPrint"]),
 
     .target(name: "HtmlPrettyPrint", dependencies: ["DoctorPretty", "Html"]),
     .testTarget(name: "HtmlPrettyPrintTests", dependencies: ["HtmlPrettyPrint"]),

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     .testTarget(name: "CssResetTests", dependencies: ["CssReset"]),
 
     .target(name: "Html", dependencies: ["Prelude"]),
-    .testTarget(name: "HtmlTests", dependencies: ["Html", "HtmlCssSupport"]),
+    .testTarget(name: "HtmlTests", dependencies: ["Html", "HtmlCssSupport", "HtmlPrettyPrint"]),
 
     .target(name: "HtmlCssSupport", dependencies: ["Css", "Html"]),
     .testTarget(name: "HtmlCssSupportTests", dependencies: ["HtmlCssSupport", "HtmlPrettyPrint"]),

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ let package = Package(
 
 * [`HttpPipelineHtmlSupport`](#httppipelinehtmlsupport)
 * [`HtmlCssSupport`](#htmlcsssupport)
+* [`HtmlPrettyPrint`](#htmlprettyprint)
 * [`CssReset`](#cssreset)
 
 ## `Html`
@@ -211,6 +212,58 @@ render(document)
   Go back
   <a style="color:#ff0000">Home</a>
 </p>
+```
+
+## `HtmlPrettyPrint`
+
+Contains functions for pretty printing an `Html` node (or nodes) using [DoctorPretty](https://github.com/bkase/DoctorPretty.git), a wonderful little pretty printer library. It not only takes care of adding newlines for tags so that the DOM structure is easy to read, but will also insert newlines when text goes past a column width, and even align smartly:
+
+```swift
+let doc: Node = .document(
+  [
+    body(
+      [
+        .comment("This is gonna be a long comment. Let's see what happens!"),
+        div(
+          [
+            div(
+              [
+                id("some-long-id"),
+                Html.`class`("foo bar baz"),
+              ],
+              ["hello world"]
+            ),
+            img(
+              [
+                id("cat"),
+                Html.`class`("cat"),
+                src("cat.jpg")
+              ]
+            )
+          ]
+        )
+      ]
+    )
+  ]
+)
+
+prettyPrint(node: doc, pageWidth: 40))
+```
+```html
+<!DOCTYPE html>
+<body>
+  <!-- This is gonna be a long comment.
+       Let's see what happens! -->
+  <div>
+    <div id="some-long-id"
+         class="foo bar baz">
+      hello world
+    </div>
+    <img id="cat"
+         class="cat"
+         src="cat.jpg" />
+  </div>
+</body>
 ```
 
 ## `CssReset`

--- a/README.md
+++ b/README.md
@@ -226,20 +226,8 @@ let doc: Node = .document(
         .comment("This is gonna be a long comment. Let's see what happens!"),
         div(
           [
-            div(
-              [
-                id("some-long-id"),
-                Html.`class`("foo bar baz"),
-              ],
-              ["hello world"]
-            ),
-            img(
-              [
-                id("cat"),
-                Html.`class`("cat"),
-                src("cat.jpg")
-              ]
-            )
+            div([ id("some-long-id"), Html.`class`("foo bar baz"), ], ["hello world"]),
+            img([ id("cat"), Html.`class`("cat"), src("cat.jpg") ])
           ]
         )
       ]

--- a/Sources/HTML/EncodedString.swift
+++ b/Sources/HTML/EncodedString.swift
@@ -2,7 +2,7 @@ import Foundation
 import Prelude
 
 public struct EncodedString {
-  internal let string: String
+  public let string: String
   internal init(_ string: String) {
     self.string = string
   }

--- a/Sources/HTML/HTML.swift
+++ b/Sources/HTML/HTML.swift
@@ -14,14 +14,14 @@ extension Node: ExpressibleByStringLiteral {
 }
 
 public struct Element {
-  let name: String
-  let attribs: [Attribute]
-  let content: [Node]?
+  public let name: String
+  public let attribs: [Attribute]
+  public let content: [Node]?
 }
 
 public struct Attribute {
-  let key: String
-  let value: Value
+  public let key: String
+  public let value: Value
 
   public init(_ key: String, _ value: Value) {
     self.key = key

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -62,7 +62,7 @@ private func prettyPrint(attributes attribs: [Attribute]) -> Doc {
   return (attribs.count == 0 ? .text("") : .text(" "))
     <%%> attribs
       .map(prettyPrint(attribute:))
-      .fillSep()
+      .sep()
       .hang(0)
 }
 

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -11,7 +11,8 @@ public func prettyPrint(node: Node, pageWidth: Int = 110) -> String {
 
 public func prettyPrint(nodes: [Node], pageWidth: Int = 110) -> String {
 
-  return nodes.map(prettyPrint(node:)).vcat()
+  return nodes.map(prettyPrint(node:))
+    .vcat()
     .renderPretty(ribbonFrac: 1, pageWidth: pageWidth)
     .displayString()
 }

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -9,6 +9,13 @@ public func prettyPrint(node: Node, pageWidth: Int = 110) -> String {
     .displayString()
 }
 
+public func prettyPrint(nodes: [Node], pageWidth: Int = 110) -> String {
+
+  return nodes.map(prettyPrint(node:)).vcat()
+    .renderPretty(ribbonFrac: 1, pageWidth: pageWidth)
+    .displayString()
+}
+
 private func prettyPrint(node: Node) -> Doc {
   switch node {
   case let .element(element):
@@ -25,11 +32,13 @@ private func prettyPrint(node: Node) -> Doc {
 private func prettyPrint(element: Element) -> Doc {
 
   return prettyPrintOpenTag(element: element)
-    <> (element.content ?? [])
-      .map(prettyPrint(node:))
-      .vcat()
-      .indent(2)
-    <> .hardline
+    <> (
+      element.content.map {
+        $0.map(prettyPrint(node:))
+          .vcat()
+          .indent(2)
+        } ?? .zero
+    )
     <> prettyPrintCloseTag(element: element)
 }
 
@@ -38,14 +47,13 @@ private func prettyPrintOpenTag(element: Element) -> Doc {
   return .text("<")
     <> .text(element.name)
     <> prettyPrint(attributes: element.attribs)
-    <> .text(">")
-    <> .hardline
+    <> (element.content == nil ? .zero : .text(">") <> .hardline)
 }
 
 private func prettyPrintCloseTag(element: Element) -> Doc {
-  return .text("</")
-    <> .text(element.name)
-    <> .text(">")
+  return element.content == nil
+    ? .text(" />")
+    : .hardline <> .text("</") <> .text(element.name) <> .text(">")
 }
 
 private func prettyPrint(attributes attribs: [Attribute]) -> Doc {

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -1,0 +1,83 @@
+import DoctorPretty
+import Operadics
+import Html
+
+public func prettyPrint(
+  node: Node,
+  pageWidth: Int = 110
+  ) -> String {
+
+  return (prettyPrint(node: node) as Doc)
+    .renderPretty(ribbonFrac: 1, pageWidth: pageWidth)
+    .displayString()
+}
+
+private func prettyPrint(node: Node) -> Doc {
+  switch node {
+  case let .element(element):
+    return prettyPrint(element: element)
+  case let .text(text):
+    return .text(text.string)
+  case let .comment(comment):
+    return prettyPrint(comment: comment)
+  case let .document(nodes):
+    return prettyPrint(document: nodes)
+  }
+}
+
+private func prettyPrint(element: Element) -> Doc {
+
+  return prettyPrintOpenTag(element: element)
+    <> (element.content ?? [])
+      .map(prettyPrint(node:))
+      .vcat()
+      .indent(2)
+    <> .hardline
+    <> prettyPrintCloseTag(element: element)
+}
+
+private func prettyPrintOpenTag(element: Element) -> Doc {
+
+  return .text("<")
+    <> .text(element.name)
+    <> prettyPrint(attributes: element.attribs)
+    <> .text(">")
+    <> .hardline
+}
+
+private func prettyPrintCloseTag(element: Element) -> Doc {
+  return .text("</")
+    <> .text(element.name)
+    <> .text(">")
+}
+
+private func prettyPrint(attributes attribs: [Attribute]) -> Doc {
+
+  return (attribs.count == 0 ? .text("") : .text(" "))
+    <%%> attribs
+      .map(prettyPrint(attribute:))
+      .fillSep()
+      .hang(0)
+}
+
+private func prettyPrint(attribute: Attribute) -> Doc {
+  return .text(attribute.value.render(with: attribute.key)?.string ?? "")
+}
+
+private func prettyPrint(comment: String) -> Doc {
+  return Doc.text("<!--")
+    <%> comment
+      .split(separator: " ")
+      .map(String.init)
+      .map(Doc.text)
+      .fillSep()
+      .hang(0)
+    <%> Doc.text("-->")
+}
+
+private func prettyPrint(document nodes: [Node]) -> Doc {
+  return Doc.text("<!DOCTYPE html>")
+    <> .hardline
+    <> nodes.map(prettyPrint(node:)).vcat()
+}
+

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -2,10 +2,7 @@ import DoctorPretty
 import Operadics
 import Html
 
-public func prettyPrint(
-  node: Node,
-  pageWidth: Int = 110
-  ) -> String {
+public func prettyPrint(node: Node, pageWidth: Int = 110) -> String {
 
   return (prettyPrint(node: node) as Doc)
     .renderPretty(ribbonFrac: 1, pageWidth: pageWidth)

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -71,18 +71,18 @@ private func prettyPrint(attribute: Attribute) -> Doc {
 }
 
 private func prettyPrint(comment: String) -> Doc {
-  return Doc.text("<!--")
+  return .text("<!--")
     <%> comment
       .split(separator: " ")
       .map(String.init)
       .map(Doc.text)
       .fillSep()
       .hang(0)
-    <%> Doc.text("-->")
+    <%> .text("-->")
 }
 
 private func prettyPrint(document nodes: [Node]) -> Doc {
-  return Doc.text("<!DOCTYPE html>")
+  return .text("<!DOCTYPE html>")
     <> .hardline
     <> nodes.map(prettyPrint(node:)).vcat()
 }

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -1,6 +1,6 @@
 import DoctorPretty
-import Operadics
 import Html
+import Operadics
 
 public func prettyPrint(node: Node, pageWidth: Int = 110) -> String {
 

--- a/Tests/HTMLTests/FullDocumentTests.swift
+++ b/Tests/HTMLTests/FullDocumentTests.swift
@@ -1,6 +1,7 @@
 import Css
 import Html
 import HtmlCssSupport
+import HtmlPrettyPrint
 import Prelude
 import XCTest
 
@@ -118,8 +119,6 @@ class FullDocumentTests: XCTestCase {
       ]
     )
 
-    let htmlString = render(htmlNode, config: pretty)
-
     XCTAssertEqual(
       """
 <html>
@@ -207,9 +206,8 @@ class FullDocumentTests: XCTestCase {
     </footer>
   </body>
 </html>
-
 """,
-      htmlString
+      prettyPrint(node: htmlNode)
     )
   }
 }

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -1,6 +1,7 @@
 import Css
 import Html
 import HtmlCssSupport
+import HtmlPrettyPrint
 import Prelude
 import XCTest
 
@@ -153,9 +154,8 @@ class HTMLTests: XCTestCase {
     </p>
   </body>
 </html>
-
 """,
-      Html.render(htmlNode, config: pretty)
+      prettyPrint(node: htmlNode)
     )
   }
 

--- a/Tests/HTMLTests/ViewTests.swift
+++ b/Tests/HTMLTests/ViewTests.swift
@@ -2,6 +2,7 @@ import Css
 import Prelude
 import Html
 import HtmlCssSupport
+import HtmlPrettyPrint
 import XCTest
 
 class ViewTests: XCTestCase {
@@ -47,7 +48,8 @@ class ViewTests: XCTestCase {
           ]
     }
 
-    XCTAssertEqual("""
+    XCTAssertEqual(
+      """
 <header style="color:#ff0000">
   <h1>
     Point Free
@@ -61,8 +63,9 @@ class ViewTests: XCTestCase {
     © Point Free LLC, 2017
   </p>
 </footer>
-
-""", main.rendered(with: 12, config: pretty))
+""",
+      prettyPrint(nodes: main.view(12))
+    )
   }
 
   func testProfunctor() {
@@ -86,9 +89,8 @@ class ViewTests: XCTestCase {
 <span style="color:#0000ff">
   {color:#0000ff}
 </span>
-
 """,
-      blueSpan.rendered(with: .empty, config: pretty)
+      prettyPrint(nodes: blueSpan.view(.empty))
     )
   }
 }

--- a/Tests/HtmlCssSupportTests/SupportTests.swift
+++ b/Tests/HtmlCssSupportTests/SupportTests.swift
@@ -1,6 +1,7 @@
 import Css
 import Html
 import HtmlCssSupport
+import HtmlPrettyPrint
 import XCTest
 
 class SupportTests: XCTestCase {
@@ -29,9 +30,8 @@ class SupportTests: XCTestCase {
     </style>
   </head>
 </html>
-
 """,
-      render(document, config: pretty)
+      prettyPrint(node: document)
     )
   }
 }

--- a/Tests/HtmlPrettyPrintTests/PrettyTests.swift
+++ b/Tests/HtmlPrettyPrintTests/PrettyTests.swift
@@ -10,19 +10,25 @@ class PrettyTests: XCTestCase {
       [
         body(
           [
-            .comment("This is gonna be a long comment. I wonder what is going to happen!"),
+            .comment("This is gonna be a long comment. Let's see what happens!"),
             div(
               [
                 div(
                   [
                     id("some-long-id"),
                     Html.`class`("foo bar baz"),
-                    style("color: red;")
+                    style("color: red;"),
                   ],
                   ["hello world"]
                 ),
                 p(["goodbye world"]),
-                img([src("cat.jpg")])
+                img(
+                  [
+                    id("cat"),
+                    Html.`class`("cat"),
+                    src("cat.jpg")
+                  ]
+                )
               ]
             )
           ]
@@ -34,9 +40,8 @@ class PrettyTests: XCTestCase {
       """
 <!DOCTYPE html>
 <body>
-  <!-- This is gonna be a long
-       comment. I wonder what
-       is going to happen! -->
+  <!-- This is gonna be a long comment.
+       Let's see what happens! -->
   <div>
     <div id="some-long-id"
          class="foo bar baz"
@@ -46,10 +51,12 @@ class PrettyTests: XCTestCase {
     <p>
       goodbye world
     </p>
-    <img src="cat.jpg" />
+    <img id="cat"
+         class="cat"
+         src="cat.jpg" />
   </div>
 </body>
 """,
-      prettyPrint(node: doc, pageWidth: 30))
+      prettyPrint(node: doc, pageWidth: 40))
   }
 }

--- a/Tests/HtmlPrettyPrintTests/PrettyTests.swift
+++ b/Tests/HtmlPrettyPrintTests/PrettyTests.swift
@@ -14,21 +14,11 @@ class PrettyTests: XCTestCase {
             div(
               [
                 div(
-                  [
-                    id("some-long-id"),
-                    Html.`class`("foo bar baz"),
-                    style("color: red;"),
-                  ],
+                  [ id("some-long-id"), Html.`class`("foo bar baz"), style("color: red;") ],
                   ["hello world"]
                 ),
                 p(["goodbye world"]),
-                img(
-                  [
-                    id("cat"),
-                    Html.`class`("cat"),
-                    src("cat.jpg")
-                  ]
-                )
+                img([ id("cat"), Html.`class`("cat"), src("cat.jpg") ])
               ]
             )
           ]

--- a/Tests/HtmlPrettyPrintTests/PrettyTests.swift
+++ b/Tests/HtmlPrettyPrintTests/PrettyTests.swift
@@ -22,6 +22,7 @@ class PrettyTests: XCTestCase {
                   ["hello world"]
                 ),
                 p(["goodbye world"]),
+                img([src("cat.jpg")])
               ]
             )
           ]
@@ -45,6 +46,7 @@ class PrettyTests: XCTestCase {
     <p>
       goodbye world
     </p>
+    <img src="cat.jpg" />
   </div>
 </body>
 """,

--- a/Tests/HtmlPrettyPrintTests/PrettyTests.swift
+++ b/Tests/HtmlPrettyPrintTests/PrettyTests.swift
@@ -1,0 +1,53 @@
+import DoctorPretty
+import Html
+import HtmlPrettyPrint
+import XCTest
+
+class PrettyTests: XCTestCase {
+
+  func testPretty() {
+    let doc: Node = .document(
+      [
+        body(
+          [
+            .comment("This is gonna be a long comment. I wonder what is going to happen!"),
+            div(
+              [
+                div(
+                  [
+                    id("some-long-id"),
+                    Html.`class`("foo bar baz"),
+                    style("color: red;")
+                  ],
+                  ["hello world"]
+                ),
+                p(["goodbye world"]),
+              ]
+            )
+          ]
+        )
+      ]
+    )
+
+    XCTAssertEqual(
+      """
+<!DOCTYPE html>
+<body>
+  <!-- This is gonna be a long
+       comment. I wonder what
+       is going to happen! -->
+  <div>
+    <div id="some-long-id"
+         class="foo bar baz"
+         style="color: red;">
+      hello world
+    </div>
+    <p>
+      goodbye world
+    </p>
+  </div>
+</body>
+""",
+      prettyPrint(node: doc, pageWidth: 30))
+  }
+}


### PR DESCRIPTION
This adds a whole new package `import HtmlPrettyPrint` that uses @bkase's [DoctorPretty](https://github.com/bkase/DoctorPretty.git) lib to do a prettier render of HTML. It was pretty easy to set up, and will be super useful for tests!