### PR TITLE
Some cleanup

### DIFF
--- a/Sources/ApplicativeRouter/ApplicativeRouter.swift
+++ b/Sources/ApplicativeRouter/ApplicativeRouter.swift
@@ -129,7 +129,7 @@ public func method(_ method: Method) -> Parser<()> {
   }
 }
 
-public let get = method(.get)
+public let get = method(.get) <|> head
 public let post = method(.post)
 public let put = method(.put)
 public let patch = method(.patch)

--- a/Sources/CSS/Common.swift
+++ b/Sources/CSS/Common.swift
@@ -11,60 +11,88 @@ public let inheritValue: Value = "inherit"
 public protocol Inherit {
   static var inherit: Self { get }
 }
+extension Value: Inherit {
+  public static var inherit: Value { return inheritValue }
+}
 
 public let noneValue: Value = "none"
 public protocol None {
   static var none: Self { get }
+}
+extension Value: None {
+  public static var none: Value { return noneValue }
 }
 
 public let normalValue: Value = "normal"
 public protocol Normal {
   static var normal: Self { get }
 }
+extension Value: Normal {
+  public static var normal: Value { return normalValue }
+}
 
 public let centerValue: Value = "center"
 public protocol Center {
   static var center: Self { get }
+}
+extension Value: Center {
+  public static var center: Value { return centerValue }
 }
 
 public let hiddenValue: Value = "hidden"
 public protocol Hidden {
   static var hidden: Self { get }
 }
+extension Value: Hidden {
+  public static var hidden: Value { return hiddenValue }
+}
 
 public let visibleValue: Value = "visible"
 public protocol Visible {
   static var visible: Self { get }
+}
+extension Value: Visible {
+  public static var visible: Value { return visibleValue }
 }
 
 public let baselineValue: Value = "baseline"
 public protocol Baseline {
   static var baseline: Self { get }
 }
+extension Value: Baseline {
+  public static var baseline: Value { return baselineValue }
+}
 
 public let autoValue: Value = "auto"
 public protocol Auto {
   static var auto: Self { get }
+}
+extension Value: Auto {
+  public static var auto: Value { return autoValue }
 }
 
 public let allValue: Value = "all"
 public protocol All {
   static var all: Self { get }
 }
+extension Value: All {
+  public static var all: Value { return allValue }
+}
 
 public let initialValue: Value = "initial"
 public protocol Initial {
   static var initial: Self { get }
+}
+extension Value: Initial {
+  public static var initial: Value { return initialValue }
 }
 
 public let unsetValue: Value = "unset"
 public protocol Unset {
   static var unset: Self { get }
 }
-
-extension Value: Inherit, None {
-  public static var inherit: Value { return inheritValue }
-  public static var none: Value { return noneValue }
+extension Value: Unset {
+  public static var unset: Value { return unsetValue }
 }
 
 public let browsers = Prefixed.prefixed(

--- a/Sources/CSS/Display.swift
+++ b/Sources/CSS/Display.swift
@@ -19,7 +19,6 @@ public func visibility(_ v: Visibility) -> Stylesheet {
 public let collapse: Visibility = "collapse"
 public let separate: Visibility = "separate"
 
-
 public struct FloatStyle: Val, None, Inherit {
   let style: Value
 

--- a/Sources/HTML/Attributes.swift
+++ b/Sources/HTML/Attributes.swift
@@ -1,26 +1,3 @@
-public enum Method: Value {
-  case get
-  case post
-
-  public func render(with key: String) -> EncodedString? {
-    switch self {
-    case .get:
-      return encode("method=") + quote(encode("GET"))
-    case .post:
-      return encode("method=") + quote(encode("POST"))
-    }
-  }
-
-  public func renderedValue() -> EncodedString? {
-    switch self {
-    case .get:
-      return encode("GET")
-    case .post:
-      return encode("POST")
-    }
-  }
-}
-
 public func action(_ action: String) -> Attribute {
   return Attribute("action", action)
 }
@@ -82,6 +59,27 @@ public func maxlength(_ maxlength: Int) -> Attribute {
   return Attribute("maxlength", maxlength)
 }
 
+public enum Method: Value {
+  case get
+  case post
+
+  public func render(with key: String) -> EncodedString? {
+    return self.renderedValue().map { encode("method=") + quote($0) }
+  }
+
+  public func renderedValue() -> EncodedString? {
+    return encode(self.description)
+  }
+
+  public var description: String {
+    switch self {
+    case .get:
+      return "GET"
+    case .post:
+      return "POST"
+    }
+  }
+}
 public func method(_ method: Method) -> Attribute {
   return Attribute("method", method)
 }
@@ -142,6 +140,40 @@ public func style(_ style: String) -> Attribute {
   return Attribute("style", style)
 }
 
+public enum Target: Value {
+  case blank
+  case `self`
+  case parent
+  case top
+  case frame(named: String)
+
+  public func render(with key: String) -> EncodedString? {
+    return self.renderedValue().map { encode("target=") + quote($0) }
+  }
+
+  public func renderedValue() -> EncodedString? {
+    return encode(self.description)
+  }
+
+  public var description: String {
+    switch self {
+    case .blank:
+      return "_blank"
+    case .self:
+      return "_self"
+    case .parent:
+      return "_parent"
+    case .top:
+      return "_top"
+    case .frame(let name):
+      return name
+    }
+  }
+}
+public func target(_ target: Target) -> Attribute {
+  return Attribute("target", target)
+}
+
 public func type(_ type: String) -> Attribute {
   return Attribute("type", type)
 }
@@ -152,4 +184,29 @@ public func value(_ value: String) -> Attribute {
 
 public func width(_ width: Int) -> Attribute {
   return Attribute("width", width)
+}
+
+public enum Wrap: Value {
+  case hard
+  case soft
+
+  public func render(with key: String) -> EncodedString? {
+    return self.renderedValue().map { encode("wrap=") + quote($0) }
+  }
+
+  public func renderedValue() -> EncodedString? {
+    return encode(self.description)
+  }
+
+  public var description: String {
+    switch self {
+    case .hard:
+      return "hard"
+    case .soft:
+      return "soft"
+    }
+  }
+}
+public func wrap(_ wrap: Wrap) -> Attribute {
+  return Attribute("wrap", wrap)
 }


### PR DESCRIPTION
We looked at this a bit but I was based on an older branch. What's the `renderedValue` stuff? Seems to overlap with `render(with key:)`?