### PR TITLE
Use static members on Stylesheet and Values

### DIFF
--- a/Sources/Css/Background.swift
+++ b/Sources/Css/Background.swift
@@ -8,8 +8,10 @@ extension Background {
   }
 }
 
-public func background<B: Background>(_ b: B) -> Stylesheet {
-  return b.background()
+extension Stylesheet {
+  public static func background<B: Background>(_ b: B) -> Stylesheet {
+    return b.background()
+  }
 }
 
 extension Color: Background {}

--- a/Sources/Css/Border.swift
+++ b/Sources/Css/Border.swift
@@ -16,6 +16,16 @@ public struct BorderStyle: Val, Other, Inherit, Auto, None {
   public static let auto = BorderStyle(stroke: .auto)
   public static let inherit = BorderStyle(stroke: .inherit)
   public static let none = BorderStyle(stroke: .none)
+
+  public static let dashed: BorderStyle = "dashed"
+  public static let dotted: BorderStyle = "dotted"
+  public static let double: BorderStyle = "double"
+  public static let groove: BorderStyle = "groove"
+  public static let hidden: BorderStyle = "hidden"
+  public static let inset: BorderStyle = "inset"
+  public static let outset: BorderStyle = "outset"
+  public static let ridge: BorderStyle = "ridge"
+  public static let solid: BorderStyle = "solid"
 }
 
 extension BorderStyle: ExpressibleByStringLiteral {
@@ -24,114 +34,106 @@ extension BorderStyle: ExpressibleByStringLiteral {
   }
 }
 
-public let solid: BorderStyle = "solid"
-public let dotted: BorderStyle = "dotted"
-public let dashed: BorderStyle = "dashed"
-public let double: BorderStyle = "double"
-public let groove: BorderStyle = "groove"
-public let ridge: BorderStyle = "ridge"
-public let inset: BorderStyle = "inset"
-public let outset: BorderStyle = "outset"
-public let hidden: BorderStyle = "hidden"
+extension Stylesheet {
+  public static func borderStyle(top: BorderStyle? = nil,
+                                 right: BorderStyle? = nil,
+                                 bottom: BorderStyle? = nil,
+                                 left: BorderStyle? = nil) -> Stylesheet {
 
-public func borderStyle(top: BorderStyle? = nil,
-                        right: BorderStyle? = nil,
-                        bottom: BorderStyle? = nil,
-                        left: BorderStyle? = nil) -> Stylesheet {
+    return [ top.map { key("border-top-style", $0) },
+             right.map { key("border-right-style", $0) },
+             bottom.map { key("border-bottom-style", $0) },
+             left.map { key("border-left-style", $0) } ]
+      |> catOptionals
+      |> concat
+  }
 
-  return [ top.map { key("border-top-style", $0) },
-           right.map { key("border-right-style", $0) },
-           bottom.map { key("border-bottom-style", $0) },
-           left.map { key("border-left-style", $0) } ]
-    |> catOptionals
-    |> concat
-}
+  public static func borderStyle(topBottom: BorderStyle? = nil, leftRight: BorderStyle? = nil) -> Stylesheet {
+    return borderStyle(top: topBottom, bottom: topBottom)
+      <> borderStyle(right: leftRight, left: leftRight)
+  }
 
-public func borderStyle(topBottom: BorderStyle? = nil, leftRight: BorderStyle? = nil) -> Stylesheet {
-  return borderStyle(top: topBottom, bottom: topBottom)
-    <> borderStyle(right: leftRight, left: leftRight)
-}
+  public static func borderStyle(all: BorderStyle) -> Stylesheet {
+    return borderStyle(top: all, right: all, bottom: all, left: all)
+  }
 
-public func borderStyle(all: BorderStyle) -> Stylesheet {
-  return borderStyle(top: all, right: all, bottom: all, left: all)
-}
+  // MARK: - border-*-radius
 
-// MARK: - border-*-radius
+  public static func borderRadius(topLeft: Size? = nil,
+                           topRight: Size? = nil,
+                           bottomRight: Size? = nil,
+                           bottomLeft: Size? = nil) -> Stylesheet {
 
-public func borderRadius(topLeft: Size? = nil,
-                         topRight: Size? = nil,
-                         bottomRight: Size? = nil,
-                         bottomLeft: Size? = nil) -> Stylesheet {
+    return [ topLeft.map { key("border-top-left-radius", $0) },
+             topRight.map { key("border-top-right-radius", $0) },
+             bottomRight.map { key("border-bottom-right-radius", $0) },
+             bottomLeft.map { key("border-bottom-left-radius", $0) } ]
+      |> catOptionals
+      |> concat
+  }
 
-  return [ topLeft.map { key("border-top-left-radius", $0) },
-           topRight.map { key("border-top-right-radius", $0) },
-           bottomRight.map { key("border-bottom-right-radius", $0) },
-           bottomLeft.map { key("border-bottom-left-radius", $0) } ]
-    |> catOptionals
-    |> concat
-}
+  public static func borderRadius(top: Size? = nil, bottom: Size? = nil) -> Stylesheet {
+    return borderRadius(topLeft: top, topRight: top)
+      <> borderRadius(bottomRight: bottom, bottomLeft: bottom)
+  }
 
-public func borderRadius(top: Size? = nil, bottom: Size? = nil) -> Stylesheet {
-  return borderRadius(topLeft: top, topRight: top)
-    <> borderRadius(bottomRight: bottom, bottomLeft: bottom)
-}
+  public static func borderRadius(all: Size) -> Stylesheet {
+    return borderRadius(topLeft: all, topRight: all, bottomRight: all, bottomLeft: all)
+  }
 
-public func borderRadius(all: Size) -> Stylesheet {
-  return borderRadius(topLeft: all, topRight: all, bottomRight: all, bottomLeft: all)
-}
+  // MARK: - border-collapse
 
-// MARK: - border-collapse
+  public static let borderCollapse: (Visibility) -> Stylesheet = key("border-collapse")
 
-public let borderCollapse: (Visibility) -> Stylesheet = key("border-collapse")
+  // Mark: border-spacing
 
-// Mark: border-spacing
+  public static let borderSpacing: (Size) -> Stylesheet = key("border-spacing")
 
-public let borderSpacing: (Size) -> Stylesheet = key("border-spacing")
+  // MARK: - border-color-*
 
-// MARK: - border-color-*
+  public static func borderColor(top: Color? = nil,
+                                 right: Color? = nil,
+                                 bottom: Color? = nil,
+                                 left: Color? = nil) -> Stylesheet {
 
-public func borderColor(top: Color? = nil,
-                        right: Color? = nil,
-                        bottom: Color? = nil,
-                        left: Color? = nil) -> Stylesheet {
+    return [ top.map { key("border-top-color", $0) },
+             right.map { key("border-right-color", $0) },
+             bottom.map { key("border-bottom-color", $0) },
+             left.map { key("border-left-color", $0) } ]
+      |> catOptionals
+      |> concat
+  }
 
-  return [ top.map { key("border-top-color", $0) },
-           right.map { key("border-right-color", $0) },
-           bottom.map { key("border-bottom-color", $0) },
-           left.map { key("border-left-color", $0) } ]
-    |> catOptionals
-    |> concat
-}
+  public static func borderColor(topBottom: Color? = nil, leftRight: Color? = nil) -> Stylesheet {
+    return borderColor(top: topBottom, bottom: topBottom)
+      <> borderColor(right: leftRight, left: leftRight)
+  }
 
-public func borderColor(topBottom: Color? = nil, leftRight: Color? = nil) -> Stylesheet {
-  return borderColor(top: topBottom, bottom: topBottom)
-    <> borderColor(right: leftRight, left: leftRight)
-}
+  public static func borderColor(all: Color) -> Stylesheet {
+    return borderColor(top: all, right: all, bottom: all, left: all)
+  }
 
-public func borderColor(all: Color) -> Stylesheet {
-  return borderColor(top: all, right: all, bottom: all, left: all)
-}
+  // MARK: - border-width-*
 
-// MARK: - border-width-*
+  public static func borderWidth(top: Size? = nil,
+                                 right: Size? = nil,
+                                 bottom: Size? = nil,
+                                 left: Size? = nil) -> Stylesheet {
 
-public func borderWidth(top: Size? = nil,
-                        right: Size? = nil,
-                        bottom: Size? = nil,
-                        left: Size? = nil) -> Stylesheet {
+    return [ top.map { key("border-top-width", $0) },
+             right.map { key("border-right-width", $0) },
+             bottom.map { key("border-bottom-width", $0) },
+             left.map { key("border-left-width", $0) } ]
+      |> catOptionals
+      |> concat
+  }
 
-  return [ top.map { key("border-top-width", $0) },
-           right.map { key("border-right-width", $0) },
-           bottom.map { key("border-bottom-width", $0) },
-           left.map { key("border-left-width", $0) } ]
-    |> catOptionals
-    |> concat
-}
+  public static func borderWidth(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
+    return borderWidth(top: topBottom, bottom: topBottom)
+      <> borderWidth(right: leftRight, left: leftRight)
+  }
 
-public func borderWidth(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
-  return borderWidth(top: topBottom, bottom: topBottom)
-    <> borderWidth(right: leftRight, left: leftRight)
-}
-
-public func borderWidth(all: Size) -> Stylesheet {
-  return borderWidth(top: all, right: all, bottom: all, left: all)
+  public static func borderWidth(all: Size) -> Stylesheet {
+    return borderWidth(top: all, right: all, bottom: all, left: all)
+  }
 }

--- a/Sources/Css/Box.swift
+++ b/Sources/Css/Box.swift
@@ -8,6 +8,10 @@ public struct BoxType: Val, Inherit {
   }
 
   public static let inherit = BoxType(boxType: .inherit)
+
+  public static let paddingBox: BoxType = "padding-box"
+  public static let borderBox: BoxType = "border-box"
+  public static let contentBox: BoxType = "content-box"
 }
 
 extension BoxType: ExpressibleByStringLiteral {
@@ -16,10 +20,8 @@ extension BoxType: ExpressibleByStringLiteral {
   }
 }
 
-public let paddingBox: BoxType = "padding-box"
-public let borderBox: BoxType = "border-box"
-public let contentBox: BoxType = "content-box"
-
-public func boxSizing(_ type: BoxType) -> Stylesheet {
-  return prefixed(browsers <> "box-sizing", type)
+extension Stylesheet {
+  public static func boxSizing(_ type: BoxType) -> Stylesheet {
+    return prefixed(browsers <> "box-sizing", type)
+  }
 }

--- a/Sources/Css/Color.swift
+++ b/Sources/Css/Color.swift
@@ -1,5 +1,23 @@
 import Prelude
 
+public enum ColorVal: Val, Auto, Inherit, None {
+  public static let auto: ColorVal = .other(.auto)
+  public static let inherit: ColorVal = .other(.inherit)
+  public static let none: ColorVal = .other(.none)
+
+  case rgba(Color)
+  case other(Value)
+
+  public func value() -> Value {
+    switch self {
+    case let .rgba(color):
+      return color.value()
+    case let .other(value):
+      return value
+    }
+  }
+}
+
 public struct Color {
   private(set) var red: Float {
     didSet {

--- a/Sources/Css/Display.swift
+++ b/Sources/Css/Display.swift
@@ -4,6 +4,9 @@ public struct Visibility: Val {
   public func value() -> Value {
     return self.visibility
   }
+
+  public static let collapse: Visibility = "collapse"
+  public static let separate: Visibility = "separate"
 }
 
 extension Visibility: ExpressibleByStringLiteral {
@@ -12,12 +15,9 @@ extension Visibility: ExpressibleByStringLiteral {
   }
 }
 
-public func visibility(_ v: Visibility) -> Stylesheet {
-  return key("visibility", v)
+extension Stylesheet {
+  public static let visibility: (Visibility) -> Stylesheet = key("visibility")
 }
-
-public let collapse: Visibility = "collapse"
-public let separate: Visibility = "separate"
 
 public struct FloatStyle: Val, None, Inherit {
   let style: Value
@@ -28,6 +28,13 @@ public struct FloatStyle: Val, None, Inherit {
 
   public static let none = FloatStyle(style: .none)
   public static let inherit = FloatStyle(style: .inherit)
+
+  public static let left: FloatStyle = "left"
+  public static let right: FloatStyle = "right"
+}
+
+extension Stylesheet {
+  public static let float: (FloatStyle) -> Stylesheet = key("float")
 }
 
 extension FloatStyle: ExpressibleByStringLiteral {
@@ -35,11 +42,6 @@ extension FloatStyle: ExpressibleByStringLiteral {
     self = .init(style: .init(stringLiteral: value))
   }
 }
-
-public let floatLeft: FloatStyle = "left"
-public let floatRight: FloatStyle = "right"
-
-public let float: (FloatStyle) -> Stylesheet = key("float")
 
 public struct Clear: Val, Other, None, Inherit {
   let clear: Value
@@ -54,6 +56,10 @@ public struct Clear: Val, Other, None, Inherit {
 
   public static let none = Clear(clear: .none)
   public static let inherit = Clear(clear: .inherit)
+
+  public static let clearLeft: Clear = "left"
+  public static let clearRight: Clear = "right"
+  public static let clearBoth: Clear = "both"
 }
 
 extension Clear: ExpressibleByStringLiteral {
@@ -62,11 +68,9 @@ extension Clear: ExpressibleByStringLiteral {
   }
 }
 
-public let clearLeft: Clear = "left"
-public let clearRight: Clear = "right"
-public let clearBoth: Clear = "both"
-
-public let clear: (Clear) -> Stylesheet = key("clear")
+extension Stylesheet {
+  public static let clear: (Clear) -> Stylesheet = key("clear")
+}
 
 public struct Position: Val, Other, Inherit {
   let position: Value
@@ -80,6 +84,11 @@ public struct Position: Val, Other, Inherit {
   }
 
   public static let inherit = Position(position: .inherit)
+
+  public static let `static`: Position = "static"
+  public static let absolute: Position = "absolute"
+  public static let fixed: Position = "fixed"
+  public static let relative: Position = "relative"
 }
 
 extension Position: ExpressibleByStringLiteral {
@@ -88,12 +97,9 @@ extension Position: ExpressibleByStringLiteral {
   }
 }
 
-public let `static`: Position = "static"
-public let absolute: Position = "absolute"
-public let fixed: Position = "fixed"
-public let relative: Position = "relative"
-
-public let position: (Position) -> Stylesheet = key("position")
+extension Stylesheet {
+  public static let position: (Position) -> Stylesheet = key("position")
+}
 
 public struct Display: Val, Other, None, Inherit {
   let display: Value
@@ -108,6 +114,10 @@ public struct Display: Val, Other, None, Inherit {
 
   public static let none = Display(display: .none)
   public static let inherit = Display(display: .inherit)
+
+  public static let block: Display = "block"
+  public static let inlineBlock: Display = "inline-block"
+  public static let table: Display = "table"
 }
 
 extension Display: ExpressibleByStringLiteral {
@@ -116,11 +126,9 @@ extension Display: ExpressibleByStringLiteral {
   }
 }
 
-public let block: Display = "block"
-public let inlineBlock: Display = "inline-block"
-public let displayTable: Display = "table"
-
-public let display: (Display) -> Stylesheet = key("display")
+extension Stylesheet {
+  public static let display: (Display) -> Stylesheet = key("display")
+}
 
 public protocol VerticalAlign: Val {
   func verticalAlign() -> Stylesheet
@@ -139,6 +147,12 @@ public struct VerticalAlignValue: Val, Baseline, Center {
 
   public static let baseline = VerticalAlignValue(.baseline)
   public static let center = VerticalAlignValue(.center)
+
+  public static let middle: VerticalAlignValue = "middle"
+  public static let top: VerticalAlignValue = "top"
+  public static let bottom: VerticalAlignValue = "bottom"
+  public static let textTop: VerticalAlignValue = "text-top"
+  public static let textBottom: VerticalAlignValue = "text-bottom"
 }
 
 extension VerticalAlignValue: ExpressibleByStringLiteral {
@@ -147,10 +161,6 @@ extension VerticalAlignValue: ExpressibleByStringLiteral {
   }
 }
 
-public let middle: VerticalAlignValue = "middle"
-public let top: VerticalAlignValue = "top"
-public let bottom: VerticalAlignValue = "bottom"
-public let textTop: VerticalAlignValue = "text-top"
-public let textBottom: VerticalAlignValue = "text-bottom"
-
-public let verticalAlign: (VerticalAlignValue) -> Stylesheet = key("vertical-align")
+extension Stylesheet {
+  public static let verticalAlign: (VerticalAlignValue) -> Stylesheet = key("vertical-align")
+}

--- a/Sources/Css/Font.swift
+++ b/Sources/Css/Font.swift
@@ -8,28 +8,12 @@ extension Font {
   }
 }
 
-public func color(_ c: Color) -> Stylesheet {
-  return key("color", c)
-}
-
-public func lineHeight(_ size: Size) -> Stylesheet {
-  return key("line-height", size)
-}
-
 public struct FontSize: Val {
   let size: Value
 
   public func value() -> Value {
     return self.size
   }
-}
-
-public func fontSize(_ size: Size) -> Stylesheet {
-  return key("font-size", size)
-}
-
-public func font<F: Font>(_ f: F) -> Stylesheet {
-  return key("font", f)
 }
 
 public struct GenericFontFamily: Val, Inherit {
@@ -42,17 +26,6 @@ public struct GenericFontFamily: Val, Inherit {
   public static let inherit = GenericFontFamily(family: .inherit)
 }
 
-public func fontFamily(_ families: [String]) -> Stylesheet {
-  return key(
-    "font-family",
-    Value(.plain(families.joined(separator: ",")))
-  )
-}
-
-public func fontFamily(_ family: GenericFontFamily) -> Stylesheet {
-  return key("font-family", family)
-}
-
 public struct FontStyle: Val, Inherit {
   public let style: Value
 
@@ -63,10 +36,6 @@ public struct FontStyle: Val, Inherit {
   public static let inherit = FontStyle(style: .inherit)
 }
 
-public func fontStyle(_ style: FontStyle) -> Stylesheet {
-  return key("font-style", style)
-}
-
 public struct FontWeight: Val, Inherit {
   let weight: Value
 
@@ -75,14 +44,28 @@ public struct FontWeight: Val, Inherit {
   }
 
   public static let inherit = FontWeight(weight: .inherit)
+
+  public static let bold = FontWeight(weight: .init(.plain("bold")))
+
+  public static func weight(_ weight: Int) -> FontWeight {
+    return .init(weight: .init(.plain(String(weight))))
+  }
 }
 
-public let bold = FontWeight(weight: .init(.plain("bold")))
+extension Stylesheet {
+  public static let color: (Color) -> Stylesheet = key("color")
+  public static let font: (Color) -> Stylesheet = key("font")
+  public static let fontFamily: (GenericFontFamily) -> Stylesheet = key("font-family")
 
-public func weight(_ w: Int) -> FontWeight {
-  return .init(weight: .init(.plain(String(w))))
-}
+  public func fontFamily(_ families: [String]) -> Stylesheet {
+    return key(
+      "font-family",
+      Value(.plain(families.joined(separator: ",")))
+    )
+  }
 
-public func fontWeight(_ weight: FontWeight) -> Stylesheet {
-  return key("font-weight", weight)
+  public static let fontSize: (Size) -> Stylesheet = key("font-size")
+  public static let fontStyle: (FontStyle) -> Stylesheet = key("font-style")
+  public static let fontWeight: (FontWeight) -> Stylesheet = key("font-weight")
+  public static let lineHeight: (Size) -> Stylesheet = key("line-height")
 }

--- a/Sources/Css/Geometry.swift
+++ b/Sources/Css/Geometry.swift
@@ -18,57 +18,60 @@ public struct EdgeInsets: Val {
   }
 }
 
-public func padding(top: Size? = nil,
-                    right: Size? = nil,
-                    bottom: Size? = nil,
-                    left: Size? = nil) -> Stylesheet {
+extension Stylesheet {
+  public static func padding(top: Size? = nil,
+                             right: Size? = nil,
+                             bottom: Size? = nil,
+                             left: Size? = nil) -> Stylesheet {
 
-  return [ top.map { key("padding-top", $0) },
-           right.map { key("padding-right", $0) },
-           bottom.map { key("padding-bottom", $0) },
-           left.map { key("padding-left", $0) } ]
-    |> catOptionals
-    |> concat
+    return [ top.map { key("padding-top", $0) },
+             right.map { key("padding-right", $0) },
+             bottom.map { key("padding-bottom", $0) },
+             left.map { key("padding-left", $0) } ]
+      |> catOptionals
+      |> concat
+  }
+
+  public static func padding(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
+
+    return padding(top: topBottom, bottom: topBottom)
+      <> padding(right: leftRight, left: leftRight)
+  }
+
+  public static func padding(all: Size) -> Stylesheet {
+    return padding(top: all, right: all, bottom: all, left: all)
+  }
+
+  public static func margin(top: Size? = nil, right: Size? = nil, bottom: Size? = nil, left: Size? = nil)
+    -> Stylesheet {
+
+    return [ top.map { key("margin-top", $0) },
+             right.map { key("margin-right", $0) },
+             bottom.map { key("margin-bottom", $0) },
+             left.map { key("margin-left", $0) } ]
+      |> catOptionals
+      |> concat
+  }
+
+  public static func margin(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
+
+    return margin(top: topBottom, bottom: topBottom)
+      <> margin(right: leftRight, left: leftRight)
+  }
+
+  public static func margin(all: Size) -> Stylesheet {
+    return margin(top: all, right: all, bottom: all, left: all)
+  }
+
+  public static let size: (Size) -> Stylesheet = key("size")
+  public static let top: (Size) -> Stylesheet = key("top")
+  public static let left: (Size) -> Stylesheet = key("left")
+  public static let bottom: (Size) -> Stylesheet = key("bottom")
+  public static let right: (Size) -> Stylesheet = key("right")
+  public static let width: (Size) -> Stylesheet = key("width")
+  public static let height: (Size) -> Stylesheet = key("height")
+  public static let maxWidth: (Size) -> Stylesheet = key("max-width")
+  public static let minWidth: (Size) -> Stylesheet = key("min-width")
+  public static let minHeight: (Size) -> Stylesheet = key("min-height")
+  public static let maxHeight: (Size) -> Stylesheet = key("max-height")
 }
-
-public func padding(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
-
-  return padding(top: topBottom, bottom: topBottom)
-    <> padding(right: leftRight, left: leftRight)
-}
-
-public func padding(all: Size) -> Stylesheet {
-  return padding(top: all, right: all, bottom: all, left: all)
-}
-
-public func margin(top: Size? = nil, right: Size? = nil, bottom: Size? = nil, left: Size? = nil) -> Stylesheet {
-
-  return [ top.map { key("margin-top", $0) },
-           right.map { key("margin-right", $0) },
-           bottom.map { key("margin-bottom", $0) },
-           left.map { key("margin-left", $0) } ]
-    |> catOptionals
-    |> concat
-}
-
-public func margin(topBottom: Size? = nil, leftRight: Size? = nil) -> Stylesheet {
-
-  return margin(top: topBottom, bottom: topBottom)
-    <> margin(right: leftRight, left: leftRight)
-}
-
-public func margin(all: Size) -> Stylesheet {
-  return margin(top: all, right: all, bottom: all, left: all)
-}
-
-public let size: (Size) -> Stylesheet = key("size")
-public func top(_ s: Size) -> Stylesheet { return key("top") <| s }
-public let left: (Size) -> Stylesheet = key("left")
-public func bottom(_ s: Size) -> Stylesheet { return key("bottom") <| s }
-public let right: (Size) -> Stylesheet = key("right")
-public let width: (Size) -> Stylesheet = key("width")
-public let height: (Size) -> Stylesheet = key("height")
-public let maxWidth: (Size) -> Stylesheet = key("max-width")
-public let minWidth: (Size) -> Stylesheet = key("min-width")
-public let minHeight: (Size) -> Stylesheet = key("min-height")
-public let maxHeight: (Size) -> Stylesheet = key("max-height")

--- a/Sources/Css/List.swift
+++ b/Sources/Css/List.swift
@@ -9,4 +9,6 @@ public struct ListStyleType: Val, Inherit, None {
   public static let none = ListStyleType(type: .none)
 }
 
-public let listStyleType: (ListStyleType) -> Stylesheet = key("list-style-type")
+extension Stylesheet {
+  public static let listStyleType: (ListStyleType) -> Stylesheet = key("list-style-type")
+}

--- a/Sources/Css/Size.swift
+++ b/Sources/Css/Size.swift
@@ -28,6 +28,30 @@ indirect public enum Size: Val, Auto, Normal, Inherit, None, Other {
   public static let inherit = Size.otherSize(.inherit)
   public static let none = Size.otherSize(.none)
   public static let normal = Size.otherSize(.normal)
+
+  public static func pct(_ d: Double) -> Size {
+    return .simple("\(trunc(d))%")
+  }
+
+  public static func px(_ d: Double) -> Size {
+    return .simple("\(trunc(d))px")
+  }
+
+  public static func rem(_ d: Double) -> Size {
+    return .simple("\(trunc(d))rem")
+  }
+
+  public static func em(_ d: Double) -> Size {
+    return .simple("\(trunc(d))em")
+  }
+
+  public static func unitless(_ d: Double) -> Size {
+    return .simple("\(trunc(d))")
+  }
+
+  public static func pt(_ d: Double) -> Size {
+    return .simple("\(trunc(d))pt")
+  }
 }
 
 private func renderExpression(size: Size) -> String {
@@ -50,30 +74,6 @@ private func renderExpression(size: Size) -> String {
 private func trunc(_ d: Double) -> String {
   let s = String(d)
   return s.hasSuffix(".0") ? String(s.dropLast(2)) : s
-}
-
-public func pct(_ d: Double) -> Size {
-  return .simple("\(trunc(d))%")
-}
-
-public func px(_ d: Double) -> Size {
-  return .simple("\(trunc(d))px")
-}
-
-public func rem(_ d: Double) -> Size {
-  return .simple("\(trunc(d))rem")
-}
-
-public func em(_ d: Double) -> Size {
-  return .simple("\(trunc(d))em")
-}
-
-public func unitless(_ d: Double) -> Size {
-  return .simple("\(trunc(d))")
-}
-
-public func pt(_ d: Double) -> Size {
-  return .simple("\(trunc(d))pt")
 }
 
 public func + (lhs: Size, rhs: Size) -> Size {

--- a/Sources/Css/Text.swift
+++ b/Sources/Css/Text.swift
@@ -8,8 +8,8 @@ public struct Content: Val, None {
   public static let none = Content(content: .none)
 }
 
-public func content(_ c: Content) -> Stylesheet {
-  return key("content", c)
+extension Stylesheet {
+  public static let content: (Content) -> Stylesheet = key("content")
 }
 
 public func stringContent(_ s: String) -> Content {
@@ -26,8 +26,8 @@ public struct Quotes: Val, None {
   public static let none = Quotes(quote: .none)
 }
 
-public func quotes(_ q: Quotes) -> Stylesheet {
-  return key("quotes", q)
+extension Stylesheet {
+  public static let quotes: (Quotes) -> Stylesheet = key("quotes")
 }
 
 public struct TextAlign: Val, Normal, Inherit, Other, Center {
@@ -48,6 +48,11 @@ public struct TextAlign: Val, Normal, Inherit, Other, Center {
   public static let center = TextAlign(.center)
   public static let normal = TextAlign(.normal)
   public static let inherit = TextAlign(.inherit)
+
+  public static let justify: TextAlign = "justify"
+  public static let matchParent: TextAlign = "match-parent"
+  public static let start: TextAlign = "start"
+  public static let end: TextAlign = "end"
 }
 
 extension TextAlign: ExpressibleByStringLiteral {
@@ -56,9 +61,6 @@ extension TextAlign: ExpressibleByStringLiteral {
   }
 }
 
-public let justify: TextAlign = "justify"
-public let matchParent: TextAlign = "match-parent"
-public let start: TextAlign = "start"
-public let end: TextAlign = "end"
-
-public let textAlign: (TextAlign) -> Stylesheet = key("text-align")
+extension Stylesheet {
+  public static let textAlign: (TextAlign) -> Stylesheet = key("text-align")
+}

--- a/Sources/CssReset/Reset.swift
+++ b/Sources/CssReset/Reset.swift
@@ -66,13 +66,13 @@ private let allReset: Stylesheet = (
     | ul
     | video
   ) % (
-    margin(all: 0)
-      <> padding(all: 0)
-      <> fontSize(pct(100))
-      <> fontFamily(.inherit)
-      <> fontStyle(.inherit)
-      <> fontWeight(.inherit)
-      <> verticalAlign(.baseline)
+    .margin(all: 0)
+      <> .padding(all: 0)
+      <> .fontSize(.pct(100))
+      <> .fontFamily(.inherit)
+      <> .fontStyle(.inherit)
+      <> .fontWeight(.inherit)
+      <> .verticalAlign(.baseline)
 )
 
 private let blockResets = (
@@ -83,12 +83,12 @@ private let blockResets = (
     | nav
     | section
   ) % (
-    display(block)
+    .display(.block)
 )
 
 private let bodyReset: Stylesheet
   = body % (
-    lineHeight(1)
+    .lineHeight(1)
 )
 
 private let quoteReset: Stylesheet
@@ -100,22 +100,22 @@ private let quoteReset: Stylesheet
       | q & .pseudoElem(.after)
 
     ) % (
-      content(stringContent(""))
-        <> content(.none)
+      .content(stringContent(""))
+        <> .content(.none)
     )
     <>
     (blockquote | q) % (
-      quotes(.none)
+      .quotes(.none)
 )
 
 private let listReset = (ol | ul) % (
-  listStyleType(.none)
+  .listStyleType(.none)
 )
 
 private let tableResets =
   table % (
-    borderCollapse(collapse)
-      <> borderSpacing(0)
+    .borderCollapse(.collapse)
+      <> .borderSpacing(0)
 )
 
 public let reset: Stylesheet =

--- a/Tests/CssTests/BackgroundTests.swift
+++ b/Tests/CssTests/BackgroundTests.swift
@@ -5,7 +5,7 @@ import Css
 class BackgroundTests: XCTestCase {
   func testBackground_RGBA() {
 
-    let css: Stylesheet = background(rgba(200, 100, 50, 1))
+    let css: Stylesheet = .background(rgba(200, 100, 50, 1))
 
     XCTAssertEqual("background:#c86432", render(config: inline, css: css))
   }

--- a/Tests/CssTests/BorderTests.swift
+++ b/Tests/CssTests/BorderTests.swift
@@ -5,11 +5,11 @@ import Css
 class BorderTests: XCTestCase {
   func testBorders() {
     let css = p % (
-      borderRadius(topLeft: 1, topRight: 2, bottomRight: 3, bottomLeft: 4)
-        <> borderColor(top: red, right: blue, bottom: green, left: red)
-        <> borderStyle(top: solid, right: dotted, bottom: dashed, left: groove)
-        <> borderCollapse(separate)
-        <> borderWidth(top: 4, right: 3, bottom: 2, left: 1)
+      .borderRadius(topLeft: 1, topRight: 2, bottomRight: 3, bottomLeft: 4)
+        <> .borderColor(top: red, right: blue, bottom: green, left: red)
+        <> .borderStyle(top: .solid, right: .dotted, bottom: .dashed, left: .groove)
+        <> .borderCollapse(.separate)
+        <> .borderWidth(top: 4, right: 3, bottom: 2, left: 1)
     )
 
     XCTAssertEqual(

--- a/Tests/CssTests/FullStylesheetTests.swift
+++ b/Tests/CssTests/FullStylesheetTests.swift
@@ -9,15 +9,15 @@ class FullStylesheetTests: XCTestCase {
   func testABigStyleSheet() {
     let css: Stylesheet =
       body % (
-        background(red)
+        .background(red)
           <> (a & .pseudo(.firstChild)) % (
-            color(blue)
+            .color(blue)
         )
     )
     <> (ul ** li) % (
-      color(red)
+      .color(red)
         <> (.pseudo(.firstChild)) & (
-          color(blue)
+          .color(blue)
       )
     )
 

--- a/Tests/CssTests/MediaTests.swift
+++ b/Tests/CssTests/MediaTests.swift
@@ -7,10 +7,10 @@ class MediaTests: XCTestCase {
   func testMediaQueryOnly() {
 
     let css =
-      body % background(blue)
+      body % .background(blue)
         <>
-        queryOnly(screen, [maxWidth(px(550))]) {
-          body % background(red)
+        queryOnly(screen, [maxWidth(.px(550))]) {
+          body % .background(red)
     }
 
 
@@ -37,8 +37,8 @@ body {
 
   func testMediaQueryNot() {
     let css =
-      queryNot(print, [maxWidth(px(550))]) {
-        body % background(red)
+      queryNot(print, [maxWidth(.px(550))]) {
+        body % .background(red)
     }
 
     XCTAssertEqual(

--- a/Tests/CssTests/RenderTests.swift
+++ b/Tests/CssTests/RenderTests.swift
@@ -6,7 +6,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_StandardCombinationOfElemIdClassPseudo() {
     let css = (a & .id("hello") & .`class`("world") & .pseudo(.firstChild)) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -17,7 +17,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_UsingStringLiterals() {
     let css = (a & "#hello" & ".world" & .pseudo(.firstChild)) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -28,7 +28,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Star() {
     let css = (body ** p ** .star) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -39,7 +39,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Elem() {
     let css = .elem(.footer) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -50,7 +50,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Id() {
     let css = .id("hello-world") % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -61,7 +61,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Class() {
     let css = .`class`("hello-world") % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -72,7 +72,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_PseudoClass() {
     let css = (body ** p & .pseudo(.firstChild)) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -83,7 +83,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_PseudoElem() {
     let css = (body ** p & .pseudoElem(.firstSentence)) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -94,7 +94,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Attr() {
     let css = .attr(input, .match("type", .val, "button")) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -105,7 +105,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeBeginsOperator() {
     let css = input["type"^="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -116,7 +116,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeContainsOperator() {
     let css = input["type"*="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -127,7 +127,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeValOperator() {
     let css = input["type"=="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -138,7 +138,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeEndsOperator() {
     let css = input["type"¢="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -149,7 +149,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeSpaceOperator() {
     let css = input["type"~="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -160,7 +160,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AttributeHyphenOperator() {
     let css = input["type"|="button"] % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -171,7 +171,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Child() {
     let css = .child(body, p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -182,7 +182,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_ChildOperator() {
     let css = (body > p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -193,7 +193,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Deep() {
     let css = .deep(body, p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -204,7 +204,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_DeepOperator() {
     let css = (body ** p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -215,7 +215,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Adjacent() {
     let css = .adjacent(body, p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -226,7 +226,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_AdjacentOperator() {
     let css = (body + p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -237,7 +237,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Sibling() {
     let css = .sibling(p, a) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -248,7 +248,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_SiblingOperator() {
     let css = (p ~ a) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -259,7 +259,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Combined() {
     let css = .combined(p, .`class`("hello")) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -270,7 +270,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_CombinedOperator() {
     let css = (p & .`class`("hello")) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -281,7 +281,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_Union() {
     let css = .union(a, p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -292,7 +292,7 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_UnionOperator() {
     let css = (a | p) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(
@@ -303,11 +303,11 @@ class RenderTests: XCTestCase {
 
   func testRenderSelector_NestedCss() {
     let css = (body & .id("hello")) % (
-      background(red)
+      .background(red)
         <> (p & .pseudo(.firstChild)) % (
-          background(green)
+          .background(green)
             <> (a & .`class`("blue")) % (
-              background(blue)
+              .background(blue)
           )
       )
     )
@@ -321,7 +321,7 @@ class RenderTests: XCTestCase {
   func testNestedIds() {
     let css = .id("hello") % (
       .id("world") % (
-        background(red)
+        .background(red)
       )
     )
 
@@ -333,7 +333,7 @@ class RenderTests: XCTestCase {
 
   func testRenderAfterContent() {
     let css = (blockquote & .pseudoElem(.after)) % (
-      content(stringContent(""))
+      .content(stringContent(""))
     )
 
     XCTAssertEqual(
@@ -344,7 +344,7 @@ class RenderTests: XCTestCase {
 
   func testMargins() {
     let css = span % (
-      margin(all: 0)
+      .margin(all: 0)
     )
 
     XCTAssertEqual(
@@ -355,7 +355,7 @@ class RenderTests: XCTestCase {
 
   func testFontInherit() {
     let css = (ol | ul) % (
-      listStyleType(.none)
+      .listStyleType(.none)
     )
 
     XCTAssertEqual(
@@ -367,7 +367,7 @@ class RenderTests: XCTestCase {
   func testSubCss() {
     let css = body % (
       a % (
-        background(red)
+        .background(red)
       )
     )
 
@@ -379,7 +379,7 @@ class RenderTests: XCTestCase {
 
   func testRenderBoxSizing() {
     let css = body % (
-      boxSizing(borderBox)
+      .boxSizing(.borderBox)
     )
 
     XCTAssertEqual(
@@ -401,9 +401,9 @@ body {
 
   func testASD() {
     let css = a % (
-      background(red)
+      .background(red)
         <> .`class`("active") & (
-          background(blue)
+          .background(blue)
       )
     )
 
@@ -415,7 +415,7 @@ body {
 
   func testAllOperatorsTogether() {
     let css = (body & "#home" > ".link" | (".row" ** (".column" + ".column"))) % (
-      background(red)
+      .background(red)
     )
 
     XCTAssertEqual(

--- a/Tests/CssTests/SizeTests.swift
+++ b/Tests/CssTests/SizeTests.swift
@@ -6,8 +6,8 @@ class SizeTests: XCTestCase {
 
   func testCalc() {
     let css: Stylesheet = img % (
-      width(pct(25) - px(20))
-        <> margin(all: px(10))
+      .width(.pct(25) - .px(20))
+        <> .margin(all: .px(10))
     )
 
     XCTAssertEqual(

--- a/Tests/HtmlCssSupportTests/HtmlCssSupportTests.swift
+++ b/Tests/HtmlCssSupportTests/HtmlCssSupportTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class SupportTests: XCTestCase {
   func testStyleAttribute() {
     let document = body(
-      [ style(color(red)) ],
+      [ style(.color(red)) ],
       [ "Hello world!" ]
     )
 
@@ -18,7 +18,7 @@ class SupportTests: XCTestCase {
   }
 
   func testStyleElement() {
-    let css = body % color(red)
+    let css = body % .color(red)
     let document = html([head([style(css)])])
 
     XCTAssertEqual(

--- a/Tests/HtmlTests/FullDocumentTests.swift
+++ b/Tests/HtmlTests/FullDocumentTests.swift
@@ -17,7 +17,7 @@ class FullDocumentTests: XCTestCase {
             title("The Site Title"),
             style(
               body % (
-                background(rgb(240, 240, 240))
+                .background(rgb(240, 240, 240))
               )
             )
           ]

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -83,11 +83,11 @@ class HTMLTests: XCTestCase {
 
   func testHtmlWithInlineStyles() {
     let html = p(
-      [ style <| color(red) ],
+      [ style <| .color(red) ],
       [
         "Welcome to ",
         a(
-          [ style <| background(blue) ],
+          [ style <| .background(blue) ],
           [ "Point Free" ]
         ),
         "!"

--- a/Tests/HtmlTests/ViewTests.swift
+++ b/Tests/HtmlTests/ViewTests.swift
@@ -29,7 +29,7 @@ class ViewTests: XCTestCase {
       .map { nodes in
         [
           Html.header(
-            [ style <| color(red) ],
+            [ style <| .color(red) ],
             nodes
           )
         ]
@@ -42,7 +42,7 @@ class ViewTests: XCTestCase {
         .map { nodes in
           [
             Html.footer(
-              [ style <| color(blue) ],
+              [ style <| .color(blue) ],
               nodes
             )
           ]
@@ -79,7 +79,7 @@ class ViewTests: XCTestCase {
 
     // Overrides the color rule of any css by appending it to the end.
     func set(color c: Color) -> (Stylesheet) -> Stylesheet {
-      return <>color(c)
+      return <>.color(c)
     }
 
     let blueSpan = styledSpan.contramap(set(color: blue))


### PR DESCRIPTION
Big API change but works really nicely for:

  - autocomplete
  - namespacing (`floatLeft` -> `.left`)