### PR TITLE
Type attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ let package = Package(
 An embedded domain specific language (EDSL) in Swift for modeling HTML documents. A few simple value types and functions allow you to model most of HTML, and they compose easily.
 
 ```swift
-import HTML
+import Html
 
 let document = html(
   [
@@ -77,6 +77,8 @@ The design of this library has been covered by the following articles:
 An EDSL for a CSS preprocessor like [Sass](http://sass-lang.com). A few simple value types and functions allow you to model most of CSS, and allow you express new things not possible in standard CSS.
 
 ```swift
+import Css
+
 let css = body % (
   padding(all: rem(2))
     <> background(hsl(60, 0.5, 0.8))

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -1,9 +1,10 @@
-public func action(_ action: String) -> Attribute {
-  return Attribute("action", action)
+public func action(_ action: String) -> Attribute<Element.Form> {
+  return .init("action", action)
 }
 
-public func autofocus(_ autofocus: Bool) -> Attribute {
-  return Attribute("autofocus", autofocus)
+public protocol HasAutofocus {}
+public func autofocus<T: HasAutofocus>(_ autofocus: Bool) -> Attribute<T> {
+  return .init("autofocus", autofocus)
 }
 
 public enum Charset: String {
@@ -11,137 +12,136 @@ public enum Charset: String {
   // TODO: add rest from here http://www.iana.org/assignments/character-sets/character-sets.xhtml
 }
 
-public func charset(_ charset: Charset) -> Attribute {
+public protocol HasCharset {}
+public func charset<T: HasCharset>(_ charset: Charset) -> Attribute<T> {
   return .init("charset", charset.rawValue)
 }
 
-public func checked(_ checked: Bool) -> Attribute {
-  return Attribute("checked", checked)
+public func checked(_ checked: Bool) -> Attribute<Element.Input> {
+  return .init("checked", checked)
 }
 
-public func `class`(_ `class`: String) -> Attribute {
-  return Attribute("class", `class`)
+public func `class`<T>(_ `class`: String) -> Attribute<T> {
+  return .init("class", `class`)
 }
 
-public func cols(_ cols: Int) -> Attribute {
-  return Attribute("cols", cols)
+public func cols(_ cols: Int) -> Attribute<Element.Textarea> {
+  return .init("cols", cols)
 }
 
-public func content(_ content: String) -> Attribute {
-  return Attribute("content", content)
+public func content(_ content: String) -> Attribute<Element.Meta> {
+  return .init("content", content)
 }
 
-public func disabled(_ disabled: Bool) -> Attribute {
-  return Attribute("disabled", disabled)
+public protocol HasDisabled {}
+public func disabled<T: HasDisabled>(_ disabled: Bool) -> Attribute<T> {
+  return .init("disabled", disabled)
 }
 
-public func `for`(_ `for`: String) -> Attribute {
-  return Attribute("for", `for`)
+public protocol HasFor {}
+public func `for`<T: HasFor>(_ `for`: String) -> Attribute<T> {
+  return .init("for", `for`)
 }
 
-public func href(_ href: String) -> Attribute {
-  return Attribute("href", href)
+public protocol HasHref {}
+public func href<T: HasHref>(_ href: String) -> Attribute<T> {
+  return .init("href", href)
 }
 
-public func id(_ id: String) -> Attribute {
-  return Attribute("id", id)
+public func id<T>(_ id: String) -> Attribute<T> {
+  return .init("id", id)
 }
 
-public func height(_ height: Int) -> Attribute {
-  return Attribute("height", height)
+public protocol HasHeight {}
+public func height<T: HasHeight>(_ height: Int) -> Attribute<T> {
+  return .init("height", height)
 }
 
-public func max(_ max: Int) -> Attribute {
-  return Attribute("max", max)
+public protocol HasMax {}
+public func max<T: HasMax>(_ max: Int) -> Attribute<T> {
+  return .init("max", max)
 }
 
-public func maxlength(_ maxlength: Int) -> Attribute {
-  return Attribute("maxlength", maxlength)
+public protocol HasMaxlength {}
+public func maxlength<T>(_ maxlength: Int) -> Attribute<T> {
+  return .init("maxlength", maxlength)
 }
 
-public enum Method: Value {
-  case get
-  case post
-
-  public func render(with key: String) -> EncodedString? {
-    return self.renderedValue().map { encode("method=") + quote($0) }
-  }
-
-  public func renderedValue() -> EncodedString? {
-    return encode(self.description)
-  }
-
-  public var description: String {
-    switch self {
-    case .get:
-      return "GET"
-    case .post:
-      return "POST"
-    }
-  }
+public enum Method: String, Value {
+  case get = "GET"
+  case post = "POST"
 }
-public func method(_ method: Method) -> Attribute {
-  return Attribute("method", method)
+public func method(_ method: Method) -> Attribute<Element.Form> {
+  return .init("method", method)
 }
 
-public func min(_ min: Int) -> Attribute {
-  return Attribute("min", min)
+public protocol HasMin {}
+public func min<T: HasMin>(_ min: Int) -> Attribute<T> {
+  return .init("min", min)
 }
 
-public func minlength(_ minlength: Int) -> Attribute {
-  return Attribute("minlength", minlength)
+public protocol HasMinlength {}
+public func minlength<T: HasMinlength>(_ minlength: Int) -> Attribute<T> {
+  return .init("minlength", minlength)
 }
 
-public func multiple(_ multiple: Bool) -> Attribute {
-  return Attribute("multiple", multiple)
+public protocol HasMultiple {}
+public func multiple<T: HasMultiple>(_ multiple: Bool) -> Attribute<T> {
+  return .init("multiple", multiple)
 }
 
-public func name(_ name: String) -> Attribute {
-  return Attribute("name", name)
+public protocol HasName {}
+public func name<T: HasName>(_ name: String) -> Attribute<T> {
+  return .init("name", name)
 }
 
-public func novalidate(_ novalidate: Bool) -> Attribute {
-  return Attribute("novalidate", novalidate)
+public func novalidate(_ novalidate: Bool) -> Attribute<Element.Form> {
+  return .init("novalidate", novalidate)
 }
 
-public func pattern(_ pattern: String) -> Attribute {
-  return Attribute("pattern", pattern)
+public func pattern(_ pattern: String) -> Attribute<Element.Input> {
+  return .init("pattern", pattern)
 }
 
-public func placeholder(_ placeholder: String) -> Attribute {
-  return Attribute("placeholder", placeholder)
+public protocol HasPlaceholder {}
+public func placeholder<T: HasPlaceholder>(_ placeholder: String) -> Attribute<T> {
+  return .init("placeholder", placeholder)
 }
 
-public func readonly(_ readonly: Bool) -> Attribute {
-  return Attribute("readonly", readonly)
+public protocol HasReadonly {}
+public func readonly<T>(_ readonly: Bool) -> Attribute<T> {
+  return .init("readonly", readonly)
 }
 
-public func rel(_ rel: String) -> Attribute {
-  return Attribute("rel", rel)
+public protocol HasRel {}
+public func rel<T: HasRel>(_ rel: String) -> Attribute<T> {
+  return .init("rel", rel)
 }
 
-public func required(_ required: Bool) -> Attribute {
-  return Attribute("required", required)
+public protocol HasRequired {}
+public func required<T: HasRequired>(_ required: Bool) -> Attribute<T> {
+  return .init("required", required)
 }
 
-public func rows(_ rows: Int) -> Attribute {
-  return Attribute("rows", rows)
+public func rows(_ rows: Int) -> Attribute<Element.Textarea> {
+  return .init("rows", rows)
 }
 
-public func selected(_ selected: Bool) -> Attribute {
-  return Attribute("selected", selected)
+public func selected(_ selected: Bool) -> Attribute<Element.Option> {
+  return .init("selected", selected)
 }
 
-public func src(_ src: String) -> Attribute {
-  return Attribute("src", src)
+public protocol HasSrc {}
+public func src<T: HasSrc>(_ src: String) -> Attribute<T> {
+  return .init("src", src)
 }
 
-public func step(_ step: Int) -> Attribute {
-  return Attribute("step", step)
+public func step(_ step: Int) -> Attribute<Element.Input> {
+  return .init("step", step)
 }
 
-public func style(_ style: String) -> Attribute {
-  return Attribute("style", style)
+public func style<T>(_ style: String) -> Attribute<T> {
+  return .init("style", style)
 }
 
 public enum Target: Value {
@@ -150,10 +150,6 @@ public enum Target: Value {
   case parent
   case top
   case frame(named: String)
-
-  public func render(with key: String) -> EncodedString? {
-    return self.renderedValue().map { encode("target=") + quote($0) }
-  }
 
   public func renderedValue() -> EncodedString? {
     return encode(self.description)
@@ -174,43 +170,81 @@ public enum Target: Value {
     }
   }
 }
-public func target(_ target: Target) -> Attribute {
-  return Attribute("target", target)
+public protocol HasTarget {}
+public func target<T: HasTarget>(_ target: Target) -> Attribute<T> {
+  return .init("target", target)
 }
 
-public func type(_ type: String) -> Attribute {
-  return Attribute("type", type)
+// TODO: type as media type
+public protocol HasMediaType {}
+public func type<T: HasMediaType>(_ type: String) -> Attribute<T> {
+  return .init("type", type)
 }
 
-public func value(_ value: String) -> Attribute {
-  return Attribute("value", value)
+public enum ButtonType: String, Value {
+  case button
+  case reset
+  case submit
+}
+public func type(_ type: ButtonType) -> Attribute<Element.Button> {
+  return .init("type", type)
 }
 
-public func width(_ width: Int) -> Attribute {
-  return Attribute("width", width)
+public enum InputType: String, Value {
+  case button
+  case checkbox
+  case color
+  case date
+  case datetimeLocal = "datetime-local"
+  case email
+  case file
+  case hidden
+  case image
+  case month
+  case number
+  case password
+  case radio
+  case range
+  case reset
+  case search
+  case submit
+  case tel
+  case text
+  case time
+  case url
+  case week
+}
+public func type(_ type: InputType) -> Attribute<Element.Input> {
+  return .init("type", type)
 }
 
-public enum Wrap: Value {
+public enum MenuType: String, Value {
+  case list
+  case context
+  case toolbar
+}
+public func type(_ type: MenuType) -> Attribute<Element.Menu> {
+  return .init("type", type)
+}
+
+public protocol HasValue {}
+public func value<T: HasValue>(_ value: String) -> Attribute<T> {
+  return .init("value", value)
+}
+
+public func value(_ value: Double) -> Attribute<Element.Progress> {
+  return .init("value", value)
+}
+
+public protocol HasWidth {}
+public func width<T: HasWidth>(_ width: Int) -> Attribute<T> {
+  return .init("width", width)
+}
+
+public enum Wrap: String, Value {
   case hard
   case soft
-
-  public func render(with key: String) -> EncodedString? {
-    return self.renderedValue().map { encode("wrap=") + quote($0) }
-  }
-
-  public func renderedValue() -> EncodedString? {
-    return encode(self.description)
-  }
-
-  public var description: String {
-    switch self {
-    case .hard:
-      return "hard"
-    case .soft:
-      return "soft"
-    }
-  }
 }
-public func wrap(_ wrap: Wrap) -> Attribute {
-  return Attribute("wrap", wrap)
+public func wrap(_ wrap: Wrap) -> Attribute<Element.Textarea> {
+  return .init("wrap", wrap)
 }

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -1,4 +1,61 @@
-public func a(_ attribs: [Attribute], _ content: [Node]) -> Node {
+extension Element {
+  public enum A: HasHref, HasRel, HasTarget {}
+  public enum Area: HasHref, HasRel, HasTarget {}
+  public enum Article {}
+  public enum Aside {}
+  public enum Audio: HasSrc {}
+  public enum Body {}
+  public enum Base: HasHref, HasTarget {}
+  public enum Button: HasAutofocus, HasDisabled, HasName, HasValue {}
+  public enum Canvas: HasHeight, HasWidth {}
+  public enum Div {}
+  public enum Embed: HasHeight, HasSrc, HasMediaType, HasWidth {}
+  public enum Fieldset: HasDisabled, HasName, HasTarget {}
+  public enum Form: HasName {}
+  public enum Footer {}
+  public enum H1 {}
+  public enum H2 {}
+  public enum H3 {}
+  public enum H4 {}
+  public enum H5 {}
+  public enum H6 {}
+  public enum Header {}
+  public enum Html {}
+  public enum Iframe: HasHeight, HasName, HasSrc, HasWidth {}
+  public enum Img: HasHeight, HasSrc, HasWidth {}
+  public enum Input: HasAutofocus, HasDisabled, HasHeight, HasMax, HasMaxlength, HasMin, HasMinlength,
+    HasMultiple, HasName, HasPlaceholder, HasReadonly, HasRequired, HasSrc, HasValue, HasWidth {}
+  public enum Keygen: HasAutofocus, HasDisabled, HasName {}
+  public enum Label: HasFor {}
+  public enum Li: HasValue {}
+  public enum Link: HasHref, HasRel, HasMediaType {}
+  public enum Main {}
+  public enum Map: HasName {}
+  public enum Menu {}
+  public enum Meta: HasCharset, HasName {}
+  public enum Meter: HasMax, HasMin {}
+  public enum Nav {}
+  public enum Object: HasHeight, HasName, HasMediaType, HasWidth {}
+  public enum Ol {}
+  public enum Optgroup: HasDisabled {}
+  public enum Option: HasDisabled, HasValue {}
+  public enum Output: HasFor, HasName {}
+  public enum P {}
+  public enum Param: HasName, HasValue {}
+  public enum Progress: HasMax {}
+  public enum Script: HasCharset, HasSrc, HasMediaType {}
+  public enum Select: HasAutofocus, HasDisabled, HasMultiple, HasName, HasRequired {}
+  public enum Source: HasSrc, HasMediaType {}
+  public enum Span {}
+  public enum Style: HasMediaType {}
+  public enum Track: HasSrc {}
+  public enum Textarea: HasAutofocus, HasDisabled, HasMaxlength, HasMinlength, HasName, HasPlaceholder,
+    HasReadonly, HasRequired {}
+  public enum Ul {}
+  public enum Video: HasHeight, HasSrc, HasWidth {}
+}
+
+public func a(_ attribs: [Attribute<Element.A>], _ content: [Node]) -> Node {
   return node("a", attribs, content)
 }
 
@@ -6,7 +63,7 @@ public func a(_ content: [Node]) -> Node {
   return a([], content)
 }
 
-public func article(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func article(_ attribs: [Attribute<Element.Article>], _ content: [Node]) -> Node {
   return node("article", attribs, content)
 }
 
@@ -14,7 +71,7 @@ public func article(_ content: [Node]) -> Node {
   return article([], content)
 }
 
-public func aside(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func aside(_ attribs: [Attribute<Element.Aside>], _ content: [Node]) -> Node {
   return node("aside", attribs, content)
 }
 
@@ -22,7 +79,7 @@ public func aside(_ content: [Node]) -> Node {
   return aside([], content)
 }
 
-public func body(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func body(_ attribs: [Attribute<Element.Body>], _ content: [Node]) -> Node {
   return node("body", attribs, content)
 }
 
@@ -30,7 +87,7 @@ public func body(_ content: [Node]) -> Node {
   return body([], content)
 }
 
-public func button(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func button(_ attribs: [Attribute<Element.Button>], _ content: [Node]) -> Node {
   return node("button", attribs, content)
 }
 
@@ -38,7 +95,7 @@ public func button(_ content: [Node]) -> Node {
   return button([], content)
 }
 
-public func div(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func div(_ attribs: [Attribute<Element.Div>], _ content: [Node]) -> Node {
   return node("div", attribs, content)
 }
 
@@ -46,7 +103,7 @@ public func div(_ content: [Node]) -> Node {
   return div([], content)
 }
 
-public func footer(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func footer(_ attribs: [Attribute<Element.Footer>], _ content: [Node]) -> Node {
   return node("footer", attribs, content)
 }
 
@@ -54,7 +111,7 @@ public func footer(_ content: [Node]) -> Node {
   return footer([], content)
 }
 
-public func form(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func form(_ attribs: [Attribute<Element.Form>], _ content: [Node]) -> Node {
   return node("form", attribs, content)
 }
 
@@ -62,7 +119,7 @@ public func form(_ content: [Node]) -> Node {
   return form([], content)
 }
 
-public func h1(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h1(_ attribs: [Attribute<Element.H1>], _ content: [Node]) -> Node {
   return node("h1", attribs, content)
 }
 
@@ -70,7 +127,7 @@ public func h1(_ content: [Node]) -> Node {
   return h1([], content)
 }
 
-public func h2(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h2(_ attribs: [Attribute<Element.H2>], _ content: [Node]) -> Node {
   return node("h2", attribs, content)
 }
 
@@ -78,7 +135,7 @@ public func h2(_ content: [Node]) -> Node {
   return h2([], content)
 }
 
-public func h3(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h3(_ attribs: [Attribute<Element.H3>], _ content: [Node]) -> Node {
   return node("h3", attribs, content)
 }
 
@@ -86,7 +143,7 @@ public func h3(_ content: [Node]) -> Node {
   return h3([], content)
 }
 
-public func h4(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h4(_ attribs: [Attribute<Element.H4>], _ content: [Node]) -> Node {
   return node("h4", attribs, content)
 }
 
@@ -94,7 +151,7 @@ public func h4(_ content: [Node]) -> Node {
   return h4([], content)
 }
 
-public func h5(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h5(_ attribs: [Attribute<Element.H5>], _ content: [Node]) -> Node {
   return node("h5", attribs, content)
 }
 
@@ -102,7 +159,7 @@ public func h5(_ content: [Node]) -> Node {
   return h5([], content)
 }
 
-public func h6(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func h6(_ attribs: [Attribute<Element.H6>], _ content: [Node]) -> Node {
   return node("h6", attribs, content)
 }
 
@@ -111,10 +168,10 @@ public func h6(_ content: [Node]) -> Node {
 }
 
 public func head(_ content: [Node]) -> Node {
-  return node("head", [], content)
+  return node("head", content)
 }
 
-public func header(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func header(_ attribs: [Attribute<Element.Header>], _ content: [Node]) -> Node {
   return node("header", attribs, content)
 }
 
@@ -122,7 +179,7 @@ public func header(_ content: [Node]) -> Node {
   return header([], content)
 }
 
-public func html(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func html(_ attribs: [Attribute<Element.Html>], _ content: [Node]) -> Node {
   return node("html", attribs, content)
 }
 
@@ -130,15 +187,15 @@ public func html(_ content: [Node]) -> Node {
   return html([], content)
 }
 
-public func img(_ attribs: [Attribute]) -> Node {
+public func img(_ attribs: [Attribute<Element.Img>]) -> Node {
   return node("img", attribs, nil)
 }
 
-public func input(_ attribs: [Attribute]) -> Node {
+public func input(_ attribs: [Attribute<Element.Input>]) -> Node {
   return node("input", attribs, nil)
 }
 
-public func label(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func label(_ attribs: [Attribute<Element.Label>], _ content: [Node]) -> Node {
   return node("label", attribs, content)
 }
 
@@ -146,7 +203,7 @@ public func label(_ content: [Node]) -> Node {
   return label([], content)
 }
 
-public func li(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func li(_ attribs: [Attribute<Element.Li>], _ content: [Node]) -> Node {
   return node("li", attribs, content)
 }
 
@@ -154,7 +211,7 @@ public func li(_ content: [Node]) -> Node {
   return li([], content)
 }
 
-public func main(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func main(_ attribs: [Attribute<Element.Main>], _ content: [Node]) -> Node {
   return node("main", attribs, content)
 }
 
@@ -162,7 +219,7 @@ public func main(_ content: [Node]) -> Node {
   return main([], content)
 }
 
-public func menu(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func menu(_ attribs: [Attribute<Element.Menu>], _ content: [Node]) -> Node {
   return node("menu", attribs, content)
 }
 
@@ -170,11 +227,11 @@ public func menu(_ content: [Node]) -> Node {
   return menu([], content)
 }
 
-public func meta(_ attribs: [Attribute]) -> Node {
+public func meta(_ attribs: [Attribute<Element.Meta>]) -> Node {
   return node("meta", attribs, nil)
 }
 
-public func nav(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func nav(_ attribs: [Attribute<Element.Nav>], _ content: [Node]) -> Node {
   return node("nav", attribs, content)
 }
 
@@ -182,7 +239,7 @@ public func nav(_ content: [Node]) -> Node {
   return nav([], content)
 }
 
-public func ol(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func ol(_ attribs: [Attribute<Element.Ol>], _ content: [Node]) -> Node {
   return node("ol", attribs, content)
 }
 
@@ -190,7 +247,7 @@ public func ol(_ content: [Node]) -> Node {
   return ol([], content)
 }
 
-public func p(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func p(_ attribs: [Attribute<Element.P>], _ content: [Node]) -> Node {
   return node("p", attribs, content)
 }
 
@@ -198,11 +255,11 @@ public func p(_ content: [Node]) -> Node {
   return p([], content)
 }
 
-public func script(_ attribs: [Attribute], _ script: String) -> Node {
+public func script(_ attribs: [Attribute<Element.Script>], _ script: String) -> Node {
   return node("script", attribs, [.text(EncodedString(script))])
 }
 
-public func script(_ attribs: [Attribute]) -> Node {
+public func script(_ attribs: [Attribute<Element.Script>]) -> Node {
   return node("script", attribs, [])
 }
 
@@ -210,11 +267,11 @@ public func script(_ script: String) -> Node {
   return Html.script([], script)
 }
 
-public func source(_ attribs: [Attribute]) -> Node {
+public func source(_ attribs: [Attribute<Element.Source>]) -> Node {
   return node("source", attribs, [])
 }
 
-public func span(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func span(_ attribs: [Attribute<Element.Span>], _ content: [Node]) -> Node {
   return node("span", attribs, content)
 }
 
@@ -222,15 +279,19 @@ public func span(_ content: [Node]) -> Node {
   return span([], content)
 }
 
+public func style(_ attribs: [Attribute<Element.Style>], _ css: String) -> Node {
+  return node("style", attribs, [.text(EncodedString(css))])
+}
+
 public func style(_ css: String) -> Node {
-  return node("style", [], [.text(EncodedString(css))])
+  return style([], css)
 }
 
 public func title(_ string: String) -> Node {
-  return node("title", [], [.text(encode(.init(string)))])
+  return node("title", [.text(encode(.init(string)))])
 }
 
-public func ul(_ attribs: [Attribute], _ content: [Node]) -> Node {
+public func ul(_ attribs: [Attribute<Element.Ul>], _ content: [Node]) -> Node {
   return node("ul", attribs, content)
 }
 

--- a/Sources/HtmlCssSupport/Support.swift
+++ b/Sources/HtmlCssSupport/Support.swift
@@ -1,12 +1,16 @@
 import Css
 import Html
 
-public func style(_ style: Stylesheet) -> Attribute {
+public func style<T>(_ style: Stylesheet) -> Attribute<T> {
   return .init("style", style)
 }
 
-public func style(_ css: Stylesheet) -> Node {
+public func style(_ attribs: [Attribute<Element.Style>], _ css: Stylesheet) -> Node {
   return style(render(config: Css.compact, css: css))
+}
+
+public func style(_ css: Stylesheet) -> Node {
+  return style([], css)
 }
 
 extension Stylesheet: Html.Value {

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -60,7 +60,7 @@ private func prettyPrintCloseTag(element: Element) -> Doc {
     : .hardline <> .text("</") <> .text(element.name) <> .text(">")
 }
 
-private func prettyPrint(attributes attribs: [Attribute]) -> Doc {
+private func prettyPrint(attributes attribs: [AnyAttribute]) -> Doc {
 
   return .text(attribs.count == 0 ? "" : " ")
     <> attribs
@@ -69,7 +69,7 @@ private func prettyPrint(attributes attribs: [Attribute]) -> Doc {
       .hang(0)
 }
 
-private func prettyPrint(attribute: Attribute) -> Doc {
+private func prettyPrint(attribute: AnyAttribute) -> Doc {
 
   // class attributes get special rendering logic so to make them line up
   // when they flow past the page width.

--- a/Tests/HtmlTests/FullDocumentTests.swift
+++ b/Tests/HtmlTests/FullDocumentTests.swift
@@ -109,8 +109,8 @@ class FullDocumentTests: XCTestCase {
                   [
                     h4(["Sign up for our newsletter!"]),
                     label([Html.for <| "email"], ["Email: "]),
-                    input([type <| "text", Html.name <| "email", id <| "email", Html.value <| ""]),
-                    input([type <| "submit", Html.value <| "Submit"])
+                    input([type <| .text, Html.name <| "email", id <| "email", Html.value <| ""]),
+                    input([type <| .submit, Html.value <| "Submit"])
                   ]
                 )
               ]


### PR DESCRIPTION
This adds compile-time type-checking to node attributes.

``` swift
img([href("spacer.gif")])
// error: type 'Element.Img' does not conform to protocol 'HasHref'

img([src("spacer.gif")])
// compiles file
```