### PR TITLE
Typed Child Nodes

### DIFF
--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MediaType
 import Prelude
 
@@ -28,10 +29,6 @@ public func autofocus<T: HasAutofocus>(_ value: Bool) -> Attribute<T> {
 public protocol HasAutoplay {}
 public func autoplay<T: HasAutoplay>(_ value: Bool) -> Attribute<T> {
   return .init("autoplay", value)
-}
-
-public func challenge(_ value: Bool) -> Attribute<Element.Keygen> {
-  return .init("challenge", value)
 }
 
 extension Charset: Value {}
@@ -81,6 +78,14 @@ public enum Crossorigin: String, Value {
 }
 public protocol HasCrossorigin {}
 public func crossorigin<T: HasCrossorigin>(_ value: Crossorigin) -> Attribute<T> {
+  return .init("crossorigin", value)
+}
+
+extension Date: Value {
+
+}
+public protocol HasDatetime {}
+public func datetime<T: HasDatetime>(_ value: Date) -> Attribute<T> {
   return .init("crossorigin", value)
 }
 
@@ -169,15 +174,6 @@ public func httpEquiv(_ value: HttpEquiv) -> Attribute<Element.Meta> {
 
 public func id<T>(_ value: Id) -> Attribute<T> {
   return .init("id", value)
-}
-
-public enum Keytype: String, Value {
-  case dsa
-  case ec
-  case rsa
-}
-public func keytype(_ value: Keytype) -> Attribute<Element.Keygen> {
-  return .init("keytype", value)
 }
 
 public enum Kind: String, Value {
@@ -394,7 +390,7 @@ public func loop<T: HasLoop>(_ value: Bool) -> Attribute<T> {
 }
 
 public protocol HasMax {}
-public func max<T: HasMax>(_ value: Int) -> Attribute<T> {
+public func max<T: HasMax>(_ value: Double) -> Attribute<T> {
   return .init("max", value)
 }
 
@@ -417,7 +413,7 @@ public func method(_ value: Method) -> Attribute<Element.Form> {
 }
 
 public protocol HasMin {}
-public func min<T: HasMin>(_ value: Int) -> Attribute<T> {
+public func min<T: HasMin>(_ value: Double) -> Attribute<T> {
   return .init("min", value)
 }
 
@@ -725,12 +721,13 @@ public func type(_ value: InputType) -> Attribute<Element.Input> {
   return .init("type", value)
 }
 
-public protocol HasValue {}
-public func value<T: HasValue>(_ value: String) -> Attribute<T> {
+public protocol HasStringValue {}
+public func value<T: HasStringValue>(_ value: String) -> Attribute<T> {
   return .init("value", value)
 }
 
-public func value(_ value: Double) -> Attribute<Element.Progress> {
+public protocol HasDoubleValue {}
+public func value<T: HasDoubleValue>(_ value: Double) -> Attribute<T> {
   return .init("value", value)
 }
 

--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -81,8 +81,16 @@ public func crossorigin<T: HasCrossorigin>(_ value: Crossorigin) -> Attribute<T>
   return .init("crossorigin", value)
 }
 
+private let iso8601DateFormatter: DateFormatter = {
+  let formatter = DateFormatter()
+  formatter.locale = Locale(identifier: "en_US_POSIX")
+  formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+  return formatter
+}()
 extension Date: Value {
-
+  public func renderedValue() -> EncodedString? {
+    return Html.encode(iso8601DateFormatter.string(from: self))
+  }
 }
 public protocol HasDatetime {}
 public func datetime<T: HasDatetime>(_ value: Date) -> Attribute<T> {

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -1,4 +1,8 @@
 import MediaType
+import Prelude
+
+public protocol ContainsList {}
+public protocol ContainsOptions {}
 
 extension Element {
   public enum A: HasHref, HasRel, HasTarget {}
@@ -41,14 +45,15 @@ extension Element {
   public enum H4 {}
   public enum H5 {}
   public enum H6 {}
+  public enum Head {}
   public enum Header {}
   public enum Html {}
   public enum I {}
   public enum Iframe: HasHeight, HasName, HasSrc, HasWidth {}
   public enum Img: HasAlt, HasCrossorigin, HasHeight, HasSrc, HasSrcset, HasWidth {}
   public enum Input: HasAlt, HasAutofocus, HasDisabled, HasForm, HasHeight, HasMax, HasMaxlength, HasMin,
-    HasMinlength, HasMultiple, HasName, HasPlaceholder, HasReadonly, HasRequired, HasSrc, HasValue, HasWidth {
-  }
+    HasMinlength, HasMultiple, HasName, HasPlaceholder, HasReadonly, HasRequired, HasSrc, HasValue,
+    HasWidth {}
   public enum Ins: HasCite {}
   public enum Kbd {}
   public enum Keygen: HasAutofocus, HasDisabled, HasForm, HasName {}
@@ -63,8 +68,8 @@ extension Element {
   public enum Meter: HasForm, HasMax, HasMin {}
   public enum Nav {}
   public enum Object: HasForm, HasHeight, HasName, HasMediaType, HasWidth {}
-  public enum Ol {}
-  public enum Optgroup: HasDisabled {}
+  public enum Ol: ContainsList {}
+  public enum Optgroup: ContainsOptions, HasDisabled {}
   public enum Option: HasDisabled, HasValue {}
   public enum Output: HasFor, HasForm, HasName {}
   public enum P {}
@@ -77,7 +82,8 @@ extension Element {
   public enum Samp {}
   public enum Script: HasCharset, HasCrossorigin, HasSrc, HasMediaType {}
   public enum Section {}
-  public enum Select: HasAutofocus, HasDisabled, HasForm, HasMultiple, HasName, HasRequired {}
+  public enum Select:
+    ContainsOptions, HasAutofocus, HasDisabled, HasForm, HasMultiple, HasName, HasRequired {}
   public enum Small {}
   public enum Source: HasSrc, HasSrcset, HasMediaType {}
   public enum Span {}
@@ -97,9 +103,17 @@ extension Element {
   public enum Thead {}
   public enum Tr {}
   public enum U {}
-  public enum Ul {}
+  public enum Ul: ContainsList {}
   public enum Var {}
   public enum Video: HasAutoplay, HasControls, HasHeight, HasLoop, HasMuted, HasPreload, HasSrc, HasWidth {}
+}
+
+public struct ChildOf<T> {
+  public let node: Node
+
+  public init(_ node: Node) {
+    self.node = node
+  }
 }
 
 public func a(_ attribs: [Attribute<Element.A>], _ content: [Node]) -> Node {
@@ -162,8 +176,8 @@ public func b(_ content: [Node]) -> Node {
   return b([], content)
 }
 
-public func base(_ attribs: [Attribute<Element.Base>]) -> Node {
-  return node("base", attribs, nil)
+public func base(_ attribs: [Attribute<Element.Base>]) -> ChildOf<Element.Head> {
+  return .init(node("base", attribs, nil))
 }
 
 public func bdi(_ attribs: [Attribute<Element.Bdi>], _ content: [Node]) -> Node {
@@ -182,11 +196,11 @@ public func blockquote(_ content: [Node]) -> Node {
   return blockquote([], content)
 }
 
-public func body(_ attribs: [Attribute<Element.Body>], _ content: [Node]) -> Node {
-  return node("body", attribs, content)
+public func body(_ attribs: [Attribute<Element.Body>], _ content: [Node]) -> ChildOf<Element.Html> {
+  return .init(node("body", attribs, content))
 }
 
-public func body(_ content: [Node]) -> Node {
+public func body(_ content: [Node]) -> ChildOf<Element.Html> {
   return body([], content)
 }
 
@@ -244,11 +258,11 @@ public func colgroup(_ content: [Node]) -> Node {
   return colgroup([], content)
 }
 
-public func dd(_ attribs: [Attribute<Element.Dd>], _ content: [Node]) -> Node {
-  return node("dd", attribs, content)
+public func dd(_ attribs: [Attribute<Element.Dd>], _ content: [Node]) -> ChildOf<Element.Dl> {
+  return .init(node("dd", attribs, content))
 }
 
-public func dd(_ content: [Node]) -> Node {
+public func dd(_ content: [Node]) -> ChildOf<Element.Dl> {
   return dd([], content)
 }
 
@@ -284,19 +298,19 @@ public func div(_ content: [Node]) -> Node {
   return div([], content)
 }
 
-public func dl(_ attribs: [Attribute<Element.Dl>], _ content: [Node]) -> Node {
-  return node("dl", attribs, content)
+public func dl(_ attribs: [Attribute<Element.Dl>], _ content: [ChildOf<Element.Dl>]) -> Node {
+  return node("dl", attribs, content.map(get(\.node)))
 }
 
-public func dl(_ content: [Node]) -> Node {
+public func dl(_ content: [ChildOf<Element.Dl>]) -> Node {
   return dl([], content)
 }
 
-public func dt(_ attribs: [Attribute<Element.Dt>], _ content: [Node]) -> Node {
-  return node("dt", attribs, content)
+public func dt(_ attribs: [Attribute<Element.Dt>], _ content: [Node]) -> ChildOf<Element.Dl> {
+  return .init(node("dt", attribs, content))
 }
 
-public func dt(_ content: [Node]) -> Node {
+public func dt(_ content: [Node]) -> ChildOf<Element.Dl> {
   return dt([], content)
 }
 
@@ -400,8 +414,8 @@ public func h6(_ content: [Node]) -> Node {
   return h6([], content)
 }
 
-public func head(_ content: [Node]) -> Node {
-  return node("head", content)
+public func head(_ content: [ChildOf<Element.Head>]) -> ChildOf<Element.Html> {
+  return .init(node("head", content.map(get(\.node))))
 }
 
 public func header(_ attribs: [Attribute<Element.Header>], _ content: [Node]) -> Node {
@@ -414,11 +428,11 @@ public func header(_ content: [Node]) -> Node {
 
 public let hr: Node = node("hr", nil)
 
-public func html(_ attribs: [Attribute<Element.Html>], _ content: [Node]) -> Node {
-  return node("html", attribs, content)
+public func html(_ attribs: [Attribute<Element.Html>], _ content: [ChildOf<Element.Html>]) -> Node {
+  return node("html", attribs, content.map(get(\.node)))
 }
 
-public func html(_ content: [Node]) -> Node {
+public func html(_ content: [ChildOf<Element.Html>]) -> Node {
   return html([], content)
 }
 
@@ -478,16 +492,16 @@ public func legend(_ content: [Node]) -> Node {
   return legend([], content)
 }
 
-public func li(_ attribs: [Attribute<Element.Li>], _ content: [Node]) -> Node {
-  return node("li", attribs, content)
+public func li<T: ContainsList>(_ attribs: [Attribute<Element.Li>], _ content: [Node]) -> ChildOf<T> {
+  return .init(node("li", attribs, content))
 }
 
-public func li(_ content: [Node]) -> Node {
+public func li<T: ContainsList>(_ content: [Node]) -> ChildOf<T> {
   return li([], content)
 }
 
-public func link(_ attribs: [Attribute<Element.Link>]) -> Node {
-  return node("li", attribs, nil)
+public func link(_ attribs: [Attribute<Element.Link>]) -> ChildOf<Element.Head> {
+  return .init(node("li", attribs, nil))
 }
 
 public func main(_ attribs: [Attribute<Element.Main>], _ content: [Node]) -> Node {
@@ -508,39 +522,39 @@ public func mark(_ content: [Node]) -> Node {
   return mark([], content)
 }
 
-public func meta(_ attribs: [Attribute<Element.Meta>]) -> Node {
-  return node("meta", attribs, nil)
+public func meta(_ attribs: [Attribute<Element.Meta>]) -> ChildOf<Element.Head> {
+  return .init(node("meta", attribs, nil))
 }
 
-public func meta(contentType: MediaType) -> Node {
+public func meta(contentType: MediaType) -> ChildOf<Element.Head> {
   return meta([httpEquiv(.contentType), .init("content", contentType)])
 }
 
-public func meta(defaultStyle: String) -> Node {
+public func meta(defaultStyle: String) -> ChildOf<Element.Head> {
   return meta([httpEquiv(.defaultStyle), content(defaultStyle)])
 }
 
-public func meta(refresh: Int) -> Node {
+public func meta(refresh: Int) -> ChildOf<Element.Head> {
   return meta([httpEquiv(.refresh), .init("content", refresh)])
 }
 
-public func meta(applicationName: String) -> Node {
+public func meta(applicationName: String) -> ChildOf<Element.Head> {
   return meta([name(.applicationName), content(applicationName)])
 }
 
-public func meta(author: String) -> Node {
+public func meta(author: String) -> ChildOf<Element.Head> {
   return meta([name(.author), content(author)])
 }
 
-public func meta(description: String) -> Node {
+public func meta(description: String) -> ChildOf<Element.Head> {
   return meta([name(.description), content(description)])
 }
 
-public func meta(generator: String) -> Node {
+public func meta(generator: String) -> ChildOf<Element.Head> {
   return meta([name(.generator), content(generator)])
 }
 
-public func meta(keywords: [String]) -> Node {
+public func meta(keywords: [String]) -> ChildOf<Element.Head> {
   let keywords = keywords.map { $0.replacingOccurrences(of: ",", with: "&#44;") }.joined(separator: ",")
   return meta([name(.keywords), content(keywords)])
 }
@@ -561,27 +575,29 @@ public func object(_ content: [Node]) -> Node {
   return object([], content)
 }
 
-public func ol(_ attribs: [Attribute<Element.Ol>], _ content: [Node]) -> Node {
-  return node("ol", attribs, content)
+public func ol(_ attribs: [Attribute<Element.Ol>], _ content: [ChildOf<Element.Ol>]) -> Node {
+  return node("ol", attribs, content.map(get(\.node)))
 }
 
-public func ol(_ content: [Node]) -> Node {
+public func ol(_ content: [ChildOf<Element.Ol>]) -> Node {
   return ol([], content)
 }
 
-public func optgroup(_ attribs: [Attribute<Element.Optgroup>], _ content: [Node]) -> Node {
-  return node("optgroup", attribs, content)
+public func optgroup(_ attribs: [Attribute<Element.Optgroup>], _ content: [ChildOf<Element.Optgroup>])
+  -> Node {
+    return node("optgroup", attribs, content.map(get(\.node)))
 }
 
-public func optgroup(_ content: [Node]) -> Node {
+public func optgroup(_ content: [ChildOf<Element.Optgroup>]) -> Node {
   return optgroup([], content)
 }
 
-public func option(_ attribs: [Attribute<Element.Option>], _ content: [Node]) -> Node {
-  return node("option", attribs, content)
+public func option<T: ContainsOptions>(_ attribs: [Attribute<Element.Option>], _ content: String)
+  -> ChildOf<T> {
+    return .init(node("option", attribs, [text(content)]))
 }
 
-public func option(_ content: [Node]) -> Node {
+public func option<T: ContainsOptions>(_ content: String) -> ChildOf<T> {
   return option([], content)
 }
 
@@ -645,16 +661,28 @@ public func samp(_ content: [Node]) -> Node {
   return samp([], content)
 }
 
-public func script(_ attribs: [Attribute<Element.Script>], _ script: String) -> Node {
-  return node("script", attribs, [.text(EncodedString(script))])
+public func script(_ attribs: [Attribute<Element.Script>], _ content: String) -> Node {
+  return node("script", attribs, [text(content)])
 }
 
 public func script(_ attribs: [Attribute<Element.Script>]) -> Node {
   return node("script", attribs, [])
 }
 
-public func script(_ script: String) -> Node {
-  return Html.script([], script)
+public func script(_ content: String) -> Node {
+  return script([], content)
+}
+
+public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: String) -> ChildOf<T> {
+  return .init(node("script", attribs, [text(content)]))
+}
+
+public func script<T>(_ attribs: [Attribute<Element.Script>]) -> ChildOf<T> {
+  return .init(node("script", attribs, []))
+}
+
+public func script<T>(_ content: String) -> ChildOf<T> {
+  return script([], content)
 }
 
 public func section(_ attribs: [Attribute<Element.Section>], _ content: [Node]) -> Node {
@@ -665,11 +693,11 @@ public func section(_ content: [Node]) -> Node {
   return section([], content)
 }
 
-public func select(_ attribs: [Attribute<Element.Select>], _ content: [Node]) -> Node {
-  return node("select", attribs, content)
+public func select(_ attribs: [Attribute<Element.Select>], _ content: [ChildOf<Element.Select>]) -> Node {
+  return node("select", attribs, content.map(get(\.node)))
 }
 
-public func select(_ content: [Node]) -> Node {
+public func select(_ content: [ChildOf<Element.Select>]) -> Node {
   return select([], content)
 }
 
@@ -702,10 +730,18 @@ public func strong(_ content: [Node]) -> Node {
 }
 
 public func style(_ attribs: [Attribute<Element.Style>], _ css: String) -> Node {
-  return node("style", attribs, [.text(EncodedString(css))])
+  return node("style", attribs, [text(css)])
 }
 
 public func style(_ css: String) -> Node {
+  return style([], css)
+}
+
+public func style<T>(_ attribs: [Attribute<Element.Style>], _ css: String) -> ChildOf<T> {
+  return .init(node("style", attribs, [text(css)]))
+}
+
+public func style<T>(_ css: String) -> ChildOf<T> {
   return style([], css)
 }
 
@@ -781,8 +817,8 @@ public func thead(_ content: [Node]) -> Node {
   return thead([], content)
 }
 
-public func title(_ string: String) -> Node {
-  return node("title", [text(string)])
+public func title(_ string: String) -> ChildOf<Element.Head> {
+  return .init(node("title", [text(string)]))
 }
 
 public func tr(_ attribs: [Attribute<Element.Tr>], _ content: [Node]) -> Node {
@@ -790,7 +826,7 @@ public func tr(_ attribs: [Attribute<Element.Tr>], _ content: [Node]) -> Node {
 }
 
 public func tr(_ content: [Node]) -> Node {
-  return td([], content)
+  return tr([], content)
 }
 
 public func track(_ attribs: [Attribute<Element.Track>]) -> Node {
@@ -805,11 +841,11 @@ public func u(_ content: [Node]) -> Node {
   return u([], content)
 }
 
-public func ul(_ attribs: [Attribute<Element.Ul>], _ content: [Node]) -> Node {
-  return node("ul", attribs, content)
+public func ul(_ attribs: [Attribute<Element.Ul>], _ content: [ChildOf<Element.Ul>]) -> Node {
+  return node("ul", attribs, content.map(get(\.node)))
 }
 
-public func ul(_ content: [Node]) -> Node {
+public func ul(_ content: [ChildOf<Element.Ul>]) -> Node {
   return ul([], content)
 }
 

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -580,11 +580,11 @@ public func nav(_ content: [Node]) -> Node {
   return nav([], content)
 }
 
-public func object(_ attribs: [Attribute<Element.Object>], _ content: [Node]) -> Node {
-  return node("object", attribs, content)
+public func object(_ attribs: [Attribute<Element.Object>], _ content: [ChildOf<Element.Object>]) -> Node {
+  return node("object", attribs, content.map(get(\.node)))
 }
 
-public func object(_ content: [Node]) -> Node {
+public func object(_ content: [ChildOf<Element.Object>]) -> Node {
   return object([], content)
 }
 
@@ -630,8 +630,8 @@ public func p(_ content: [Node]) -> Node {
   return p([], content)
 }
 
-public func param(_ attribs: [Attribute<Element.Param>]) -> Node {
-  return node("param", attribs, nil)
+public func param(_ attribs: [Attribute<Element.Param>]) -> ChildOf<Element.Object> {
+  return .init(node("param", attribs, nil))
 }
 
 public func picture(_ attribs: [Attribute<Element.Picture>], _ content: [ChildOf<Element.Picture>]) -> Node {
@@ -675,7 +675,7 @@ public func samp(_ content: [Node]) -> Node {
 }
 
 public func script(_ attribs: [Attribute<Element.Script>], _ content: String) -> Node {
-  return node("script", attribs, [text(content)])
+  return node("script", attribs, [.text(EncodedString(content))])
 }
 
 public func script(_ attribs: [Attribute<Element.Script>]) -> Node {
@@ -742,20 +742,12 @@ public func strong(_ content: [Node]) -> Node {
   return strong([], content)
 }
 
-public func style(_ attribs: [Attribute<Element.Style>], _ css: String) -> Node {
-  return node("style", attribs, [text(css)])
+public func style(_ attribs: [Attribute<Element.Style>], _ content: String) -> ChildOf<Element.Head> {
+  return .init(node("style", attribs, [.text(EncodedString(content))]))
 }
 
-public func style(_ css: String) -> Node {
-  return style([], css)
-}
-
-public func style<T>(_ attribs: [Attribute<Element.Style>], _ css: String) -> ChildOf<T> {
-  return .init(node("style", attribs, [text(css)]))
-}
-
-public func style<T>(_ css: String) -> ChildOf<T> {
-  return style([], css)
+public func style(_ content: String) -> ChildOf<Element.Head> {
+  return style([], content)
 }
 
 public func sub(_ attribs: [Attribute<Element.Sub>], _ content: [Node]) -> Node {

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -4,6 +4,7 @@ import Prelude
 public protocol ContainsAVSource {}
 public protocol ContainsList {}
 public protocol ContainsOptions {}
+public protocol ContainsTr {}
 public protocol ContainsTrack {}
 
 extension Element {
@@ -21,7 +22,7 @@ extension Element {
   public enum Bdo {}
   public enum Blockquote: HasCite {}
   public enum Body {}
-  public enum Button: HasAutofocus, HasDisabled, HasForm, HasName, HasValue {}
+  public enum Button: HasAutofocus, HasDisabled, HasForm, HasName, HasStringValue {}
   public enum Canvas: HasHeight, HasWidth {}
   public enum Caption {}
   public enum Cite {}
@@ -29,7 +30,7 @@ extension Element {
   public enum Col: HasSpan {}
   public enum Colgroup: HasSpan {}
   public enum Dd {}
-  public enum Del: HasCite {}
+  public enum Del: HasCite, HasDatetime {}
   public enum Details {}
   public enum Dfn {}
   public enum Div {}
@@ -54,33 +55,35 @@ extension Element {
   public enum I {}
   public enum Iframe: HasHeight, HasName, HasSrc, HasWidth {}
   public enum Img: HasAlt, HasCrossorigin, HasHeight, HasSrc, HasSrcset, HasWidth {}
-  public enum Input: HasAlt, HasAutofocus, HasDisabled, HasForm, HasHeight, HasMax, HasMaxlength, HasMin,
-    HasMinlength, HasMultiple, HasName, HasPlaceholder, HasReadonly, HasRequired, HasSrc, HasValue,
-    HasWidth {}
-  public enum Ins: HasCite {}
+  public enum Input: HasAlt, HasAutofocus, HasDisabled, HasDoubleValue, HasForm, HasHeight, HasMax,
+    HasMaxlength, HasMin, HasMinlength, HasMultiple, HasName, HasPlaceholder, HasReadonly, HasRequired,
+    HasSrc, HasStringValue, HasWidth {}
+  public enum Ins: HasCite, HasDatetime {}
   public enum Kbd {}
-  public enum Keygen: HasAutofocus, HasDisabled, HasForm, HasName {}
   public enum Label: HasFor, HasForm {}
   public enum Legend {}
-  public enum Li: HasValue {}
+  public enum Li: HasStringValue {}
   public enum Link: HasHref, HasRel, HasMediaType {}
   public enum Main {}
   public enum Mark {}
   public enum Map: HasName {}
   public enum Meta: HasCharset {}
-  public enum Meter: HasForm, HasMax, HasMin {}
+  public enum Meter: HasDoubleValue, HasForm, HasMax, HasMin {}
   public enum Nav {}
   public enum Object: HasForm, HasHeight, HasName, HasMediaType, HasWidth {}
   public enum Ol: ContainsList {}
   public enum Optgroup: ContainsOptions, HasDisabled {}
-  public enum Option: HasDisabled, HasValue {}
+  public enum Option: HasDisabled, HasStringValue {}
   public enum Output: HasFor, HasForm, HasName {}
   public enum P {}
-  public enum Param: HasName, HasValue {}
+  public enum Param: HasName, HasStringValue {}
   public enum Picture {}
   public enum Pre {}
-  public enum Progress: HasMax {}
+  public enum Progress: HasDoubleValue, HasMax {}
   public enum Q: HasCite {}
+  public enum Rp {}
+  public enum Rt {}
+  public enum Ruby {}
   public enum S {}
   public enum Samp {}
   public enum Script: HasCharset, HasCrossorigin, HasSrc, HasMediaType {}
@@ -95,15 +98,16 @@ extension Element {
   public enum Sub {}
   public enum Summary {}
   public enum Sup {}
-  public enum Table {}
-  public enum Tbody {}
+  public enum Table: ContainsTr {}
+  public enum Tbody: ContainsTr {}
   public enum Td: HasColspan, HasHeaders, HasRowspan {}
   public enum Textarea: HasAutofocus, HasDisabled, HasForm, HasMaxlength, HasMinlength, HasName,
     HasPlaceholder, HasReadonly, HasRequired {}
   public enum Tfoot {}
+  public enum Time: HasDatetime {}
   public enum Track: HasSrc {}
   public enum Th: HasColspan, HasHeaders, HasRowspan {}
-  public enum Thead {}
+  public enum Thead: ContainsTr {}
   public enum Tr {}
   public enum U {}
   public enum Ul: ContainsList {}
@@ -144,8 +148,8 @@ public func address(_ content: [Node]) -> Node {
   return address([], content)
 }
 
-public func area(_ attribs: [Attribute<Element.Area>]) -> Node {
-  return node("area", attribs, nil)
+public func area(_ attribs: [Attribute<Element.Area>]) -> ChildOf<Element.Map> {
+  return .init(node("area", attribs, nil))
 }
 
 public func article(_ attribs: [Attribute<Element.Article>], _ content: [Node]) -> Node {
@@ -197,6 +201,14 @@ public func bdi(_ content: [Node]) -> Node {
   return bdi([], content)
 }
 
+public func bdo(dir: Direction, _ attribs: [Attribute<Element.Bdi>], _ content: [Node]) -> Node {
+  return node("bdo", [Html.dir(dir)] + attribs, content)
+}
+
+public func bdo(dir: Direction, _ content: [Node]) -> Node {
+  return bdo(dir: dir, [], content)
+}
+
 public func blockquote(_ attribs: [Attribute<Element.Blockquote>], _ content: [Node]) -> Node {
   return node("blockquote", attribs, content)
 }
@@ -231,11 +243,12 @@ public func canvas(_ content: [Node]) -> Node {
   return canvas([], content)
 }
 
-public func caption(_ attribs: [Attribute<Element.Caption>], _ content: [Node]) -> Node {
-  return node("caption", attribs, content)
+// TODO: "caption" can only be the first element of a "table"
+public func caption(_ attribs: [Attribute<Element.Caption>], _ content: [Node]) -> ChildOf<Element.Table> {
+  return .init(node("caption", attribs, content))
 }
 
-public func caption(_ content: [Node]) -> Node {
+public func caption(_ content: [Node]) -> ChildOf<Element.Table> {
   return caption([], content)
 }
 
@@ -255,15 +268,17 @@ public func code(_ content: [Node]) -> Node {
   return code([], content)
 }
 
-public func col(_ attribs: [Attribute<Element.Col>]) -> Node {
-  return node("col", attribs, nil)
+public func col(_ attribs: [Attribute<Element.Col>]) -> ChildOf<Element.Colgroup> {
+  return .init(node("col", attribs, nil))
 }
 
-public func colgroup(_ attribs: [Attribute<Element.Colgroup>], _ content: [Node]) -> Node {
-  return node("colgroup", attribs, content)
+public func colgroup(_ attribs: [Attribute<Element.Colgroup>], _ content: [ChildOf<Element.Colgroup>])
+  -> ChildOf<Element.Table> {
+
+    return .init(node("colgroup", attribs, content.map(get(\.node))))
 }
 
-public func colgroup(_ content: [Node]) -> Node {
+public func colgroup(_ content: [ChildOf<Element.Colgroup>]) -> ChildOf<Element.Table> {
   return colgroup([], content)
 }
 
@@ -283,6 +298,7 @@ public func del(_ content: [Node]) -> Node {
   return del([], content)
 }
 
+// TODO: required first child element "summary"
 public func details(_ attribs: [Attribute<Element.Details>], _ content: [Node]) -> Node {
   return node("details", attribs, content)
 }
@@ -343,19 +359,21 @@ public func fieldset(_ content: [Node]) -> Node {
   return fieldset([], content)
 }
 
-public func figcaption(_ attribs: [Attribute<Element.Figcaption>], _ content: [Node]) -> Node {
-  return node("figcaption", attribs, content)
+public func figcaption(_ attribs: [Attribute<Element.Figcaption>], _ content: [Node])
+  -> ChildOf<Element.Figure> {
+
+    return .init(node("figcaption", attribs, content))
 }
 
-public func figcaption(_ content: [Node]) -> Node {
+public func figcaption(_ content: [Node]) -> ChildOf<Element.Figure> {
   return figcaption([], content)
 }
 
-public func figure(_ attribs: [Attribute<Element.Figure>], _ content: [Node]) -> Node {
-  return node("figure", attribs, content)
+public func figure(_ attribs: [Attribute<Element.Figure>], _ content: [ChildOf<Element.Figure>]) -> Node {
+  return node("figure", attribs, content.map(get(\.node)))
 }
 
-public func figure(_ content: [Node]) -> Node {
+public func figure(_ content: [ChildOf<Element.Figure>]) -> Node {
   return figure([], content)
 }
 
@@ -457,6 +475,7 @@ public func iframe(_ attribs: [Attribute<Element.Iframe>], _ content: [Node] = [
   return node("iframe", attribs, content)
 }
 
+// TODO: "img" requires "src" and "alt"
 public func img(_ attribs: [Attribute<Element.Img>]) -> Node {
   return node("img", attribs, nil)
 }
@@ -481,10 +500,6 @@ public func kbd(_ content: [Node]) -> Node {
   return kbd([], content)
 }
 
-public func keygen(_ attribs: [Attribute<Element.Keygen>]) -> Node {
-  return node("keygen", attribs, nil)
-}
-
 public func label(_ attribs: [Attribute<Element.Label>], _ content: [Node]) -> Node {
   return node("label", attribs, content)
 }
@@ -493,11 +508,11 @@ public func label(_ content: [Node]) -> Node {
   return label([], content)
 }
 
-public func legend(_ attribs: [Attribute<Element.Legend>], _ content: [Node]) -> Node {
-  return node("legend", attribs, content)
+public func legend(_ attribs: [Attribute<Element.Legend>], _ content: [Node]) -> ChildOf<Element.Fieldset> {
+  return .init(node("legend", attribs, content))
 }
 
-public func legend(_ content: [Node]) -> Node {
+public func legend(_ content: [Node]) -> ChildOf<Element.Fieldset> {
   return legend([], content)
 }
 
@@ -521,7 +536,15 @@ public func main(_ content: [Node]) -> Node {
   return main([], content)
 }
 
-// TODO: "map" element
+public func map(name: String, _ attribs: [Attribute<Element.Map>], _ content: [ChildOf<Element.Map>])
+  -> Node {
+
+    return node("map", [Html.name(name)] + attribs, content.map(get(\.node)))
+}
+
+public func map(name: String, _ content: [ChildOf<Element.Map>]) -> Node {
+  return map(name: name, [], content)
+}
 
 public func mark(_ attribs: [Attribute<Element.Mark>], _ content: [Node]) -> Node {
   return node("mark", attribs, content)
@@ -568,6 +591,14 @@ public func meta(keywords: [String]) -> ChildOf<Element.Head> {
   return meta([name(.keywords), content(keywords)])
 }
 
+public func meter(value: Double, _ attribs: [Attribute<Element.Meter>], _ content: [Node]) -> Node {
+  return node("nav", [Html.value(value)] + attribs, content)
+}
+
+public func meter(value: Double, _ content: [Node]) -> Node {
+  return meter(value: value, [], content)
+}
+
 public func nav(_ attribs: [Attribute<Element.Nav>], _ content: [Node]) -> Node {
   return node("nav", attribs, content)
 }
@@ -576,6 +607,7 @@ public func nav(_ content: [Node]) -> Node {
   return nav([], content)
 }
 
+// TODO: Required attribute "data" or "type"
 public func object(_ attribs: [Attribute<Element.Object>], _ content: [ChildOf<Element.Object>]) -> Node {
   return node("object", attribs, content.map(get(\.node)))
 }
@@ -726,7 +758,7 @@ public func small(_ content: [Node]) -> Node {
 public func source<T: ContainsAVSource>(
   src: String,
   _ attribs: [Attribute<Element.Source>],
-  _ transparent: [Node])
+  _ transparent: [Node] = [])
   -> ChildOf<T> {
     return .init(node("source", [Html.src(src)] + attribs, nil))
 }
@@ -768,11 +800,11 @@ public func sub(_ content: [Node]) -> Node {
   return sub([], content)
 }
 
-public func summary(_ attribs: [Attribute<Element.Summary>], _ content: [Node]) -> Node {
-  return node("summary", attribs, content)
+public func summary(_ attribs: [Attribute<Element.Summary>], _ content: [Node]) -> ChildOf<Element.Details> {
+  return .init(node("summary", attribs, content))
 }
 
-public func summary(_ content: [Node]) -> Node {
+public func summary(_ content: [Node]) -> ChildOf<Element.Details> {
   return summary([], content)
 }
 
@@ -792,19 +824,19 @@ public func table(_ content: [Node]) -> Node {
   return table([], content)
 }
 
-public func tbody(_ attribs: [Attribute<Element.Tbody>], _ content: [Node]) -> Node {
-  return node("tbody", attribs, content)
+public func tbody(_ attribs: [Attribute<Element.Tbody>], _ content: [Node]) -> ChildOf<Element.Table> {
+  return .init(node("tbody", attribs, content))
 }
 
-public func tbody(_ content: [Node]) -> Node {
+public func tbody(_ content: [Node]) -> ChildOf<Element.Table> {
   return tbody([], content)
 }
 
-public func td(_ attribs: [Attribute<Element.Td>], _ content: [Node]) -> Node {
-  return node("td", attribs, content)
+public func td(_ attribs: [Attribute<Element.Td>], _ content: [Node]) -> ChildOf<Element.Tr> {
+  return .init(node("td", attribs, content))
 }
 
-public func td(_ content: [Node]) -> Node {
+public func td(_ content: [Node]) -> ChildOf<Element.Tr> {
   return td([], content)
 }
 
@@ -816,36 +848,53 @@ public func textarea(_ content: String = "") -> Node {
   return textarea([], content)
 }
 
-public func th(_ attribs: [Attribute<Element.Th>], _ content: [Node]) -> Node {
-  return node("td", attribs, content)
+public func tfoot(_ attribs: [Attribute<Element.Tfoot>], _ content: [Node]) -> ChildOf<Element.Table> {
+  return .init(node("tfoot", attribs, content))
 }
 
-public func th(_ content: [Node]) -> Node {
+public func tfoot(_ content: [Node]) -> ChildOf<Element.Table> {
+  return tfoot([], content)
+}
+
+// TODO: "th" can only be within "thead" or the first "tr" of a "table"
+public func th(_ attribs: [Attribute<Element.Th>], _ content: [Node]) -> ChildOf<Element.Tr> {
+  return .init(node("td", attribs, content))
+}
+
+public func th(_ content: [Node]) -> ChildOf<Element.Tr> {
   return th([], content)
 }
 
-public func thead(_ attribs: [Attribute<Element.Thead>], _ content: [Node]) -> Node {
-  return node("thead", attribs, content)
+public func thead(_ attribs: [Attribute<Element.Thead>], _ content: [Node]) -> ChildOf<Element.Table> {
+  return .init(node("thead", attribs, content))
 }
 
-public func thead(_ content: [Node]) -> Node {
+public func thead(_ content: [Node]) -> ChildOf<Element.Table> {
   return thead([], content)
+}
+
+public func time(_ attribs: [Attribute<Element.Time>], _ content: [Node]) -> Node {
+  return node("time", attribs, content)
+}
+
+public func time(_ content: [Node]) -> Node {
+  return time([], content)
 }
 
 public func title(_ string: String) -> ChildOf<Element.Head> {
   return .init(node("title", [text(string)]))
 }
 
-public func tr(_ attribs: [Attribute<Element.Tr>], _ content: [Node]) -> Node {
-  return node("tr", attribs, content)
+public func tr<T: ContainsTr>(_ attribs: [Attribute<Element.Tr>], _ content: [Node]) -> ChildOf<T> {
+  return .init(node("tr", attribs, content))
 }
 
-public func tr(_ content: [Node]) -> Node {
+public func tr<T: ContainsTr>(_ content: [Node]) -> ChildOf<T> {
   return tr([], content)
 }
 
-public func track<T: ContainsTrack>(_ attribs: [Attribute<Element.Track>]) -> ChildOf<T> {
-  return .init(node("track", attribs, nil))
+public func track<T: ContainsTrack>(src: String, _ attribs: [Attribute<Element.Track>]) -> ChildOf<T> {
+  return .init(node("track", [Html.src(src)] + attribs, nil))
 }
 
 public func u(_ attribs: [Attribute<Element.U>], _ content: [Node]) -> Node {

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -475,9 +475,8 @@ public func iframe(_ attribs: [Attribute<Element.Iframe>], _ content: [Node] = [
   return node("iframe", attribs, content)
 }
 
-// TODO: "img" requires "src" and "alt"
-public func img(_ attribs: [Attribute<Element.Img>]) -> Node {
-  return node("img", attribs, nil)
+public func img(src: String, alt: String, _ attribs: [Attribute<Element.Img>]) -> Node {
+  return node("img", [Html.src(src), Html.alt(alt)] + attribs, nil)
 }
 
 public func input(_ attribs: [Attribute<Element.Input>]) -> Node {
@@ -665,14 +664,22 @@ public func param(_ attribs: [Attribute<Element.Param>]) -> ChildOf<Element.Obje
 public func picture(
   _ attribs: [Attribute<Element.Picture>],
   _ content: [ChildOf<Element.Picture>],
+  src: String,
+  alt: String,
   _ imgAttribs: [Attribute<Element.Img>] = [])
   -> Node {
 
-    return node("picture", attribs, content.map(get(\.node)) + [img(imgAttribs)])
+    return node("picture", attribs, content.map(get(\.node)) + [img(src: src, alt: alt, imgAttribs)])
 }
 
-public func picture(_ content: [ChildOf<Element.Picture>], _ imgAttribs: [Attribute<Element.Img>]) -> Node {
-  return picture([], content, imgAttribs)
+public func picture(
+  _ content: [ChildOf<Element.Picture>],
+  src: String,
+  alt: String,
+  _ imgAttribs: [Attribute<Element.Img>] = [])
+  -> Node {
+
+    return picture([], content, src: src, alt: alt, imgAttribs)
 }
 
 public func pre(_ attribs: [Attribute<Element.Pre>], _ content: [Node]) -> Node {
@@ -757,13 +764,13 @@ public func small(_ content: [Node]) -> Node {
 
 public func source<T: ContainsAVSource>(
   src: String,
-  _ attribs: [Attribute<Element.Source>],
+  _ attribs: [Attribute<Element.Source>] = [],
   _ transparent: [Node] = [])
   -> ChildOf<T> {
     return .init(node("source", [Html.src(src)] + attribs, nil))
 }
 
-public func source(srcset string: String, _ attribs: [Attribute<Element.Source>])
+public func source(srcset string: String, _ attribs: [Attribute<Element.Source>] = [])
   -> ChildOf<Element.Picture> {
     return .init(node("source", [srcset(string)] + attribs, nil))
 }
@@ -893,7 +900,7 @@ public func tr<T: ContainsTr>(_ content: [Node]) -> ChildOf<T> {
   return tr([], content)
 }
 
-public func track<T: ContainsTrack>(src: String, _ attribs: [Attribute<Element.Track>]) -> ChildOf<T> {
+public func track<T: ContainsTrack>(src: String, _ attribs: [Attribute<Element.Track>] = []) -> ChildOf<T> {
   return .init(node("track", [Html.src(src)] + attribs, nil))
 }
 

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -3,6 +3,8 @@ import Prelude
 
 public protocol ContainsList {}
 public protocol ContainsOptions {}
+public protocol ContainsSource {}
+public protocol ContainsTrack {}
 
 extension Element {
   public enum A: HasHref, HasRel, HasTarget {}
@@ -11,7 +13,8 @@ extension Element {
   public enum Area: HasAlt, HasHref, HasRel, HasTarget {}
   public enum Article {}
   public enum Aside {}
-  public enum Audio: HasAutoplay, HasControls, HasLoop, HasMuted, HasPreload, HasSrc {}
+  public enum Audio: ContainsSource, ContainsTrack, HasAutoplay, HasControls, HasLoop, HasMuted, HasPreload,
+    HasSrc {}
   public enum B {}
   public enum Base: HasHref, HasTarget {}
   public enum Bdi {}
@@ -74,7 +77,7 @@ extension Element {
   public enum Output: HasFor, HasForm, HasName {}
   public enum P {}
   public enum Param: HasName, HasValue {}
-  public enum Picture {}
+  public enum Picture: ContainsSource {}
   public enum Pre {}
   public enum Progress: HasMax {}
   public enum Q: HasCite {}
@@ -105,7 +108,8 @@ extension Element {
   public enum U {}
   public enum Ul: ContainsList {}
   public enum Var {}
-  public enum Video: HasAutoplay, HasControls, HasHeight, HasLoop, HasMuted, HasPreload, HasSrc, HasWidth {}
+  public enum Video: ContainsSource, ContainsTrack, HasAutoplay, HasControls, HasHeight, HasLoop, HasMuted,
+    HasPreload, HasSrc, HasWidth {}
 }
 
 public struct ChildOf<T> {
@@ -160,11 +164,11 @@ public func aside(_ content: [Node]) -> Node {
   return aside([], content)
 }
 
-public func audio(_ attribs: [Attribute<Element.Audio>], _ content: [Node]) -> Node {
-  return node("audio", attribs, content)
+public func audio(_ attribs: [Attribute<Element.Audio>], _ content: [ChildOf<Element.Audio>]) -> Node {
+  return node("audio", attribs, content.map(get(\.node)))
 }
 
-public func audio(_ content: [Node]) -> Node {
+public func audio(_ content: [ChildOf<Element.Audio>]) -> Node {
   return audio([], content)
 }
 
@@ -621,11 +625,11 @@ public func param(_ attribs: [Attribute<Element.Param>]) -> Node {
   return node("param", attribs, nil)
 }
 
-public func picture(_ attribs: [Attribute<Element.Picture>], _ content: [Node]) -> Node {
-  return node("picture", attribs, content)
+public func picture(_ attribs: [Attribute<Element.Picture>], _ content: [ChildOf<Element.Picture>]) -> Node {
+  return node("picture", attribs, content.map(get(\.node)))
 }
 
-public func picture(_ content: [Node]) -> Node {
+public func picture(_ content: [ChildOf<Element.Picture>]) -> Node {
   return picture([], content)
 }
 
@@ -709,8 +713,8 @@ public func small(_ content: [Node]) -> Node {
   return small([], content)
 }
 
-public func source(_ attribs: [Attribute<Element.Source>]) -> Node {
-  return node("source", attribs, nil)
+public func source<T: ContainsSource>(_ attribs: [Attribute<Element.Source>]) -> ChildOf<T> {
+  return .init(node("source", attribs, nil))
 }
 
 public func span(_ attribs: [Attribute<Element.Span>], _ content: [Node]) -> Node {
@@ -829,8 +833,8 @@ public func tr(_ content: [Node]) -> Node {
   return tr([], content)
 }
 
-public func track(_ attribs: [Attribute<Element.Track>]) -> Node {
-  return node("track", attribs, nil)
+public func track<T: ContainsTrack>(_ attribs: [Attribute<Element.Track>]) -> ChildOf<T> {
+  return .init(node("track", attribs, nil))
 }
 
 public func u(_ attribs: [Attribute<Element.U>], _ content: [Node]) -> Node {
@@ -857,11 +861,11 @@ public func `var`(_ content: [Node]) -> Node {
   return `var`([], content)
 }
 
-public func video(_ attribs: [Attribute<Element.Video>], _ content: [Node]) -> Node {
-  return node("video", attribs, content)
+public func video(_ attribs: [Attribute<Element.Video>], _ content: [ChildOf<Element.Video>]) -> Node {
+  return node("video", attribs, content.map(get(\.node)))
 }
 
-public func video(_ content: [Node]) -> Node {
+public func video(_ content: [ChildOf<Element.Video>]) -> Node {
   return video([], content)
 }
 

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -116,14 +116,6 @@ extension Element {
     HasPreload, HasSrc, HasWidth {}
 }
 
-public struct ChildOf<T> {
-  public let node: Node
-
-  public init(_ node: Node) {
-    self.node = node
-  }
-}
-
 public func a(_ attribs: [Attribute<Element.A>], _ content: [Node]) -> Node {
   return node("a", attribs, content)
 }

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -1,15 +1,10 @@
 import MediaType
 import Prelude
 
+public protocol ContainsAVSource {}
 public protocol ContainsList {}
 public protocol ContainsOptions {}
-public protocol ContainsSource {}
-public protocol ContainsText {}
 public protocol ContainsTrack {}
-
-public func text<T: ContainsText>(_ content: String) -> ChildOf<T> {
-  return .init(text(content))
-}
 
 extension Element {
   public enum A: HasHref, HasRel, HasTarget {}
@@ -18,8 +13,8 @@ extension Element {
   public enum Area: HasAlt, HasHref, HasRel, HasTarget {}
   public enum Article {}
   public enum Aside {}
-  public enum Audio: ContainsSource, ContainsText, ContainsTrack, HasAutoplay, HasControls, HasLoop, HasMuted,
-    HasPreload, HasSrc {}
+  public enum Audio: ContainsAVSource, ContainsTrack, HasAutoplay, HasControls, HasLoop, HasMuted, HasPreload,
+    HasSrc {}
   public enum B {}
   public enum Base: HasHref, HasTarget {}
   public enum Bdi {}
@@ -82,7 +77,7 @@ extension Element {
   public enum Output: HasFor, HasForm, HasName {}
   public enum P {}
   public enum Param: HasName, HasValue {}
-  public enum Picture: ContainsSource {}
+  public enum Picture {}
   public enum Pre {}
   public enum Progress: HasMax {}
   public enum Q: HasCite {}
@@ -113,8 +108,8 @@ extension Element {
   public enum U {}
   public enum Ul: ContainsList {}
   public enum Var {}
-  public enum Video: ContainsSource, ContainsText, ContainsTrack, HasAutoplay, HasControls, HasHeight,
-    HasLoop, HasMuted, HasPreload, HasSrc, HasWidth {}
+  public enum Video: ContainsAVSource, ContainsTrack, HasAutoplay, HasControls, HasHeight, HasLoop, HasMuted,
+    HasPreload, HasSrc, HasWidth {}
 }
 
 public struct ChildOf<T> {
@@ -169,12 +164,17 @@ public func aside(_ content: [Node]) -> Node {
   return aside([], content)
 }
 
-public func audio(_ attribs: [Attribute<Element.Audio>], _ content: [ChildOf<Element.Audio>]) -> Node {
-  return node("audio", attribs, content.map(get(\.node)))
+public func audio(
+  _ attribs: [Attribute<Element.Audio>],
+  _ content: [ChildOf<Element.Audio>],
+  _ transparent: [Node] = [])
+  -> Node {
+
+    return node("audio", attribs, content.map(get(\.node)) + transparent)
 }
 
-public func audio(_ content: [ChildOf<Element.Audio>]) -> Node {
-  return audio([], content)
+public func audio(_ content: [ChildOf<Element.Audio>], _ transparent: [Node] = []) -> Node {
+  return audio([], content, transparent)
 }
 
 public func b(_ attribs: [Attribute<Element.B>], _ content: [Node]) -> Node {
@@ -461,10 +461,6 @@ public func img(_ attribs: [Attribute<Element.Img>]) -> Node {
   return node("img", attribs, nil)
 }
 
-public func img(_ attribs: [Attribute<Element.Img>]) -> ChildOf<Element.Picture> {
-  return .init(img(attribs))
-}
-
 public func input(_ attribs: [Attribute<Element.Input>]) -> Node {
   return node("input", attribs, nil)
 }
@@ -634,12 +630,17 @@ public func param(_ attribs: [Attribute<Element.Param>]) -> ChildOf<Element.Obje
   return .init(node("param", attribs, nil))
 }
 
-public func picture(_ attribs: [Attribute<Element.Picture>], _ content: [ChildOf<Element.Picture>]) -> Node {
-  return node("picture", attribs, content.map(get(\.node)))
+public func picture(
+  _ attribs: [Attribute<Element.Picture>],
+  _ content: [ChildOf<Element.Picture>],
+  _ imgAttribs: [Attribute<Element.Img>] = [])
+  -> Node {
+
+    return node("picture", attribs, content.map(get(\.node)) + [img(imgAttribs)])
 }
 
-public func picture(_ content: [ChildOf<Element.Picture>]) -> Node {
-  return picture([], content)
+public func picture(_ content: [ChildOf<Element.Picture>], _ imgAttribs: [Attribute<Element.Img>]) -> Node {
+  return picture([], content, imgAttribs)
 }
 
 public func pre(_ attribs: [Attribute<Element.Pre>], _ content: [Node]) -> Node {
@@ -722,8 +723,17 @@ public func small(_ content: [Node]) -> Node {
   return small([], content)
 }
 
-public func source<T: ContainsSource>(_ attribs: [Attribute<Element.Source>]) -> ChildOf<T> {
-  return .init(node("source", attribs, nil))
+public func source<T: ContainsAVSource>(
+  src: String,
+  _ attribs: [Attribute<Element.Source>],
+  _ transparent: [Node])
+  -> ChildOf<T> {
+    return .init(node("source", [Html.src(src)] + attribs, nil))
+}
+
+public func source(srcset string: String, _ attribs: [Attribute<Element.Source>])
+  -> ChildOf<Element.Picture> {
+    return .init(node("source", [srcset(string)] + attribs, nil))
 }
 
 public func span(_ attribs: [Attribute<Element.Span>], _ content: [Node]) -> Node {
@@ -862,12 +872,17 @@ public func `var`(_ content: [Node]) -> Node {
   return `var`([], content)
 }
 
-public func video(_ attribs: [Attribute<Element.Video>], _ content: [ChildOf<Element.Video>]) -> Node {
-  return node("video", attribs, content.map(get(\.node)))
+public func video(
+  _ attribs: [Attribute<Element.Video>],
+  _ content: [ChildOf<Element.Video>],
+  _ transparent: [Node] = [])
+  -> Node {
+
+    return node("video", attribs, content.map(get(\.node)) + transparent)
 }
 
-public func video(_ content: [ChildOf<Element.Video>]) -> Node {
-  return video([], content)
+public func video(_ content: [ChildOf<Element.Video>], _ transparent: [Node]) -> Node {
+  return video([], content, transparent)
 }
 
 public let wbr: Node = node("wbr", nil)

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -4,7 +4,12 @@ import Prelude
 public protocol ContainsList {}
 public protocol ContainsOptions {}
 public protocol ContainsSource {}
+public protocol ContainsText {}
 public protocol ContainsTrack {}
+
+public func text<T: ContainsText>(_ content: String) -> ChildOf<T> {
+  return .init(text(content))
+}
 
 extension Element {
   public enum A: HasHref, HasRel, HasTarget {}
@@ -13,8 +18,8 @@ extension Element {
   public enum Area: HasAlt, HasHref, HasRel, HasTarget {}
   public enum Article {}
   public enum Aside {}
-  public enum Audio: ContainsSource, ContainsTrack, HasAutoplay, HasControls, HasLoop, HasMuted, HasPreload,
-    HasSrc {}
+  public enum Audio: ContainsSource, ContainsText, ContainsTrack, HasAutoplay, HasControls, HasLoop, HasMuted,
+    HasPreload, HasSrc {}
   public enum B {}
   public enum Base: HasHref, HasTarget {}
   public enum Bdi {}
@@ -108,8 +113,8 @@ extension Element {
   public enum U {}
   public enum Ul: ContainsList {}
   public enum Var {}
-  public enum Video: ContainsSource, ContainsTrack, HasAutoplay, HasControls, HasHeight, HasLoop, HasMuted,
-    HasPreload, HasSrc, HasWidth {}
+  public enum Video: ContainsSource, ContainsText, ContainsTrack, HasAutoplay, HasControls, HasHeight,
+    HasLoop, HasMuted, HasPreload, HasSrc, HasWidth {}
 }
 
 public struct ChildOf<T> {
@@ -456,6 +461,10 @@ public func img(_ attribs: [Attribute<Element.Img>]) -> Node {
   return node("img", attribs, nil)
 }
 
+public func img(_ attribs: [Attribute<Element.Img>]) -> ChildOf<Element.Picture> {
+  return .init(img(attribs))
+}
+
 public func input(_ attribs: [Attribute<Element.Input>]) -> Node {
   return node("input", attribs, nil)
 }
@@ -678,11 +687,11 @@ public func script(_ content: String) -> Node {
 }
 
 public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: String) -> ChildOf<T> {
-  return .init(node("script", attribs, [text(content)]))
+  return .init(script(attribs, content))
 }
 
 public func script<T>(_ attribs: [Attribute<Element.Script>]) -> ChildOf<T> {
-  return .init(node("script", attribs, []))
+  return .init(script(attribs))
 }
 
 public func script<T>(_ content: String) -> ChildOf<T> {

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -54,8 +54,12 @@ public func node(_ name: String, _ content: [Node]?) -> Node {
   return .element(.init(name: name, attribs: [], content: content))
 }
 
-public func text(_ text: String) -> Node {
-  return .text(encode(text))
+public func text(_ content: String) -> Node {
+  return .text(encode(content))
+}
+
+public func text<T: ContainsSource>(_ content: String) -> ChildOf<T> {
+  return .init(text(content))
 }
 
 public func attribute<T>(_ name: String, _ value: Value) -> Attribute<T> {

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -58,10 +58,6 @@ public func text(_ content: String) -> Node {
   return .text(encode(content))
 }
 
-public func text<T: ContainsSource>(_ content: String) -> ChildOf<T> {
-  return .init(text(content))
-}
-
 public func attribute<T>(_ name: String, _ value: Value) -> Attribute<T> {
   return .init(name, value)
 }

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -1,7 +1,7 @@
 import Prelude
 
 public enum Node {
-  case comment(String)
+  case comment(EncodedString)
   indirect case document([Node])
   case element(Element)
   case text(EncodedString)
@@ -10,6 +10,14 @@ public enum Node {
 extension Node: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self = .text(encode(value))
+  }
+}
+
+public struct ChildOf<T> {
+  public let node: Node
+
+  public init(_ node: Node) {
+    self.node = node
   }
 }
 
@@ -60,6 +68,14 @@ public func text(_ content: String) -> Node {
 
 public func attribute<T>(_ name: String, _ value: Value) -> Attribute<T> {
   return .init(name, value)
+}
+
+public func comment(_ content: String) -> Node {
+  return .comment(EncodedString(content))
+}
+
+public func comment<T>(_ content: String) -> ChildOf<T> {
+  return .init(comment(content))
 }
 
 extension Value {

--- a/Sources/Html/Render.swift
+++ b/Sources/Html/Render.swift
@@ -26,7 +26,7 @@ public func render(_ node: Node, config: Config = compact) -> String {
 
     switch node {
     case let .comment(string):
-      return indentation + "<!-- " + string + " -->" + config.newline
+      return indentation + "<!-- " + string.string + " -->" + config.newline
     case let .document(nodes):
       return indentation + "<!DOCTYPE html>" + config.newline + nodes
         .map { realRender($0, config: config, indentation: indentation) }

--- a/Sources/HtmlCssSupport/Support.swift
+++ b/Sources/HtmlCssSupport/Support.swift
@@ -5,11 +5,11 @@ public func style<T>(_ style: Stylesheet) -> Attribute<T> {
   return .init("style", style)
 }
 
-public func style(_ attribs: [Attribute<Element.Style>], _ css: Stylesheet) -> Node {
+public func style(_ attribs: [Attribute<Element.Style>], _ css: Stylesheet) -> ChildOf<Element.Head> {
   return style(render(config: Css.compact, css: css))
 }
 
-public func style(_ css: Stylesheet) -> Node {
+public func style(_ css: Stylesheet) -> ChildOf<Element.Head> {
   return style([], css)
 }
 

--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -24,7 +24,7 @@ private func prettyPrint(node: Node) -> Doc {
   case let .text(text):
     return prettyPrint(text: text)
   case let .comment(comment):
-    return prettyPrint(comment: comment)
+    return prettyPrint(comment: comment.string)
   case let .document(nodes):
     return prettyPrint(document: nodes)
   }

--- a/Tests/HtmlCssSupportTests/HtmlCssSupportTests.swift
+++ b/Tests/HtmlCssSupportTests/HtmlCssSupportTests.swift
@@ -6,14 +6,14 @@ import XCTest
 
 class SupportTests: XCTestCase {
   func testStyleAttribute() {
-    let document = body(
+    let node = p (
       [ style(.color(.red)) ],
       [ "Hello world!" ]
     )
 
     XCTAssertEqual(
-      "<body style=\"color:#ff0000\">Hello world!</body>",
-      render(document, config: compact)
+      "<p style=\"color:#ff0000\">Hello world!</p>",
+      render(node, config: compact)
     )
   }
 

--- a/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
+++ b/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
@@ -9,25 +9,29 @@ class PrettyTests: XCTestCase {
   func testPretty() {
     let doc: Node = .document(
       [
-        body(
+        html(
           [
-            .comment("This is gonna be a long comment. Let's see what happens!"),
-            div(
+            body(
               [
+                .comment("This is gonna be a long comment. Let's see what happens!"),
                 div(
                   [
-                    id("some-long-id"),
-                    Html.`class`("foo bar baz class1 class2 class3"),
-                    style("color: red;background: blue;padding: rem(2);")
-                  ],
-                  ["hello world"]
-                ),
-                p([
-                  """
-Tacit programming, also called point-free style, is a programming paradigm in which function definitions do not identify the arguments (or "points") on which they operate.
-"""
-]),
-                img([ id("cat"), Html.`class`("cat"), src("cat.jpg") ])
+                    div(
+                      [
+                        id("some-long-id"),
+                        Html.`class`("foo bar baz class1 class2 class3"),
+                        style("color: red;background: blue;padding: rem(2);")
+                      ],
+                      ["hello world"]
+                    ),
+                    p([
+                      """
+    Tacit programming, also called point-free style, is a programming paradigm in which function definitions do not identify the arguments (or "points") on which they operate.
+    """
+    ]),
+                    img([ id("cat"), Html.`class`("cat"), src("cat.jpg") ])
+                  ]
+                )
               ]
             )
           ]

--- a/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
+++ b/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
@@ -13,7 +13,7 @@ class PrettyTests: XCTestCase {
           [
             body(
               [
-                .comment("This is gonna be a long comment. Let's see what happens!"),
+                comment("This is gonna be a long comment. Let's see what happens!"),
                 div(
                   [
                     div(

--- a/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
+++ b/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
@@ -19,7 +19,7 @@ class PrettyTests: XCTestCase {
                     div(
                       [
                         id("some-long-id"),
-                        Html.`class`("foo bar baz class1 class2 class3"),
+                        Html.class("foo bar baz class1 class2 class3"),
                         style("color: red;background: blue;padding: rem(2);")
                       ],
                       ["hello world"]
@@ -29,7 +29,7 @@ class PrettyTests: XCTestCase {
     Tacit programming, also called point-free style, is a programming paradigm in which function definitions do not identify the arguments (or "points") on which they operate.
     """
     ]),
-                    img([ id("cat"), Html.`class`("cat"), src("cat.jpg") ])
+                    img(src: "cat.jpg", alt: "", [ id("cat"), Html.class("cat") ])
                   ]
                 )
               ]

--- a/Tests/HtmlPrettyPrintTests/__Snapshots__/HtmlPrettyPrintTests.testPretty.html
+++ b/Tests/HtmlPrettyPrintTests/__Snapshots__/HtmlPrettyPrintTests.testPretty.html
@@ -1,30 +1,34 @@
 <!DOCTYPE html>
-<body>
-  <!-- This is gonna be a long comment.
-       Let's see what happens! -->
-  <div>
-    <div id="some-long-id"
-         class="foo
-                bar
-                baz
-                class1
-                class2
-                class3"
-         style="color: red;
-                background: blue;
-                padding: rem(2);">
-      hello world
+<html>
+  <body>
+    <!-- This is gonna be a long
+         comment. Let's see what
+         happens! -->
+    <div>
+      <div id="some-long-id"
+           class="foo
+                  bar
+                  baz
+                  class1
+                  class2
+                  class3"
+           style="color: red;
+                  background: blue;
+                  padding: rem(2);">
+        hello world
+      </div>
+      <p>
+        Tacit programming, also called
+        point-free style, is a
+        programming paradigm in which
+        function definitions do not
+        identify the arguments (or
+        &quot;points&quot;) on which
+        they operate.
+      </p>
+      <img id="cat"
+           class="cat"
+           src="cat.jpg">
     </div>
-    <p>
-      Tacit programming, also called
-      point-free style, is a programming
-      paradigm in which function
-      definitions do not identify the
-      arguments (or &quot;points&quot;)
-      on which they operate.
-    </p>
-    <img id="cat"
-         class="cat"
-         src="cat.jpg">
-  </div>
-</body>
+  </body>
+</html>

--- a/Tests/HtmlPrettyPrintTests/__Snapshots__/HtmlPrettyPrintTests.testPretty.html
+++ b/Tests/HtmlPrettyPrintTests/__Snapshots__/HtmlPrettyPrintTests.testPretty.html
@@ -26,9 +26,10 @@
         &quot;points&quot;) on which
         they operate.
       </p>
-      <img id="cat"
-           class="cat"
-           src="cat.jpg">
+      <img src="cat.jpg"
+           alt=""
+           id="cat"
+           class="cat">
     </div>
   </body>
 </html>

--- a/Tests/HtmlTests/EncodedStringTests.swift
+++ b/Tests/HtmlTests/EncodedStringTests.swift
@@ -6,9 +6,8 @@ import Css
 class EncodedStringTests: XCTestCase {
   func testEscape() {
     let node = body(
-      [],
       ["/body><script>alert('BAD')</script>"]
-    )
+    ).node
 
     XCTAssertEqual(
       "<body>/body&gt;&lt;script&gt;alert(&#39;BAD&#39;)&lt;/script&gt;</body>",
@@ -18,10 +17,8 @@ class EncodedStringTests: XCTestCase {
 
   func testDoesntEscapeInStyleTag() {
     let node = head(
-      [
-        style("/body><script>alert('BAD')</script>")
-      ]
-    )
+      [style("/body><script>alert('BAD')</script>")]
+    ).node
 
     XCTAssertEqual(
       "<head><style>/body><script>alert('BAD')</script></style></head>",
@@ -31,10 +28,8 @@ class EncodedStringTests: XCTestCase {
 
   func testDoesntEscapeInScript() {
     let node = head(
-      [
-        script("/body><script>alert('BAD')</script>")
-      ]
-    )
+      [script("/body><script>alert('BAD')</script>")]
+    ).node
 
     XCTAssertEqual(
       "<head><script>/body><script>alert('BAD')</script></script></head>",

--- a/Tests/HtmlTests/FullDocumentTests.swift
+++ b/Tests/HtmlTests/FullDocumentTests.swift
@@ -99,9 +99,9 @@ class FullDocumentTests: XCTestCase {
                 h2(["The Site"]),
                 ul(
                   [
-                    a([href <| "#"], ["Contact us"]),
-                    a([href <| "#"], ["About"]),
-                    a([href <| "#"], ["Home"]),
+                    li([a([href <| "#"], ["Contact us"])]),
+                    li([a([href <| "#"], ["About"])]),
+                    li([a([href <| "#"], ["Home"])]),
                   ]
                 ),
                 form(

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class HTMLTests: XCTestCase {
   func testImgTag() {
-    let html = img(
+    let html: Node = img(
       [ src <| "cat.jpg",
         width <| 100,
         height <| 100 ]
@@ -45,17 +45,16 @@ class HTMLTests: XCTestCase {
     let testHtml = html(
       [ id <| "home" ],
       [
-        p(
-          [],
+        body(
           [
-            "Welcome to point free!"
+            p(["Welcome to point free!"])
           ]
         )
       ]
     )
 
     XCTAssertEqual(
-      "<html id=\"home\"><p>Welcome to point free!</p></html>",
+      "<html id=\"home\"><body><p>Welcome to point free!</p></body></html>",
       render(testHtml)
     )
   }
@@ -64,19 +63,23 @@ class HTMLTests: XCTestCase {
     let testHtml = html(
       [ id <| "home" ],
       [
-        a(
+        body(
           [
-            href <| "/"
-          ],
-          [
-            "Go home!"
+            a(
+              [
+                href <| "/"
+              ],
+              [
+                "Go home!"
+              ]
+            )
           ]
         )
       ]
     )
 
     XCTAssertEqual(
-      "<html id=\"home\"><a href=\"/\">Go home!</a></html>",
+      "<html id=\"home\"><body><a href=\"/\">Go home!</a></body></html>",
       render(testHtml)
     )
   }

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -120,7 +120,8 @@ class HTMLTests: XCTestCase {
       script("alert(\"Hello!\")")
     ])
 
-    XCTAssertEqual("<div><script src=\"app.js\"></script><script>alert(\"Hello!\")</script></div>", render(html))
+    XCTAssertEqual("<div><script src=\"app.js\"></script><script>alert(\"Hello!\")</script></div>",
+                   render(html))
   }
 
   func testPrettyRender() {
@@ -130,7 +131,7 @@ class HTMLTests: XCTestCase {
       [
         body(
           [
-            .comment("Welcome to our app!"),
+            comment("Welcome to our app!"),
             h1(["Title"]),
             p(
               [

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -8,27 +8,31 @@ import XCTest
 class HTMLTests: XCTestCase {
   func testImgTag() {
     let html = img(
-      [ src <| "cat.jpg",
+      src: "cat.jpg",
+      alt: "", [
         width <| 100,
-        height <| 100 ]
+        height <| 100
+      ]
     )
 
     let rendered = render(html)
 
     XCTAssertEqual(
-      "<img src=\"cat.jpg\" width=\"100\" height=\"100\">",
+      "<img src=\"cat.jpg\" alt=\"\" width=\"100\" height=\"100\">",
       rendered
     )
   }
 
   func testHtml3() {
     let html = p(
-      [ Html.`class` <| "main" ],
+      [ Html.class <| "main" ],
       [
         img(
-          [ src <| "cat.jpg",
+          src: "cat.jpg",
+          alt: "", [
             width <| 100,
-            height <| 100 ]
+            height <| 100
+          ]
         ),
 
         "A cat!"
@@ -36,7 +40,7 @@ class HTMLTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      "<p class=\"main\"><img src=\"cat.jpg\" width=\"100\" height=\"100\">A cat!</p>",
+      "<p class=\"main\"><img src=\"cat.jpg\" alt=\"\" width=\"100\" height=\"100\">A cat!</p>",
       render(html)
     )
   }

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class HTMLTests: XCTestCase {
   func testImgTag() {
-    let html: Node = img(
+    let html = img(
       [ src <| "cat.jpg",
         width <| 100,
         height <| 100 ]

--- a/Tests/HtmlTests/__Snapshots__/FullDocumentTests.testDocument.html
+++ b/Tests/HtmlTests/__Snapshots__/FullDocumentTests.testDocument.html
@@ -60,15 +60,21 @@
         The Site
       </h2>
       <ul>
-        <a href="#">
-          Contact us
-        </a>
-        <a href="#">
-          About
-        </a>
-        <a href="#">
-          Home
-        </a>
+        <li>
+          <a href="#">
+            Contact us
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            About
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            Home
+          </a>
+        </li>
       </ul>
       <form id="newsletter-form" action="#" method="POST">
         <h4>


### PR DESCRIPTION
Certain nodes can only contain certain elements:

- `head` and `body` can only be in `html`
- `link`, `meta`, and `title` can only be in `head`
- `li` can only be in `ol` and `ul`
- `dd` and `dt` can only be in `dl`

And there are more examples.

This PR adds a lightweight typed wrapper around these functions.

``` swift
ul(
  [
    a([href("/")], ["Home"]),
    a([href("/about")], ["About"]),
    a([href("/archive")], ["Archive"]),
  ]
)
// error: cannot convert value of type 'Node' to expected element type
// 'ChildOf<Element.Ul>'
//     a([href("/")], ["Home"]),
//     ^~~~~~~~~~~~~~~~~~~~~~~~
```