### PR TITLE
Support a kind of IxApply

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,15 @@ enum Route {
 
 let router =
         // Matches: GET /
-        Route.home <¢ .get <* .end
+        Route.home <¢ .get <*| end
         // Matches: GET /episode/:str
-    <|> Route.episode <¢> (.get *> lit("episode") *> .str) <* .end
+    <|> Route.episode <¢> (.get *> lit("episode") *> .str) <*| end
         // Matches: GET /episodes
-    <|> Route.episodes <¢ (.get *> lit("episodes")) <* .end
+    <|> Route.episodes <¢ (.get *> lit("episodes")) <*| end
         // Matches: GET /search?query=
-    <|> Route.search <¢> (.get *> lit("search") *> opt(param("query"))) <* .end
+    <|> Route.search <¢> (.get *> lit("search") *> opt(param("query"))) <*| end
         // Matches: POST /signup
-    <|> Route.signup <¢> (.post *> lit("signup") *> opt(.jsonBody)) <* .end
+    <|> Route.signup <¢> (.post *> lit("signup") *> opt(.jsonBody)) <*| end
 
 let request = URLRequest(url: URL(string: "http://localhost:8000/episode/001-hello-world")!)
 let route = router.match(request) // => Route.episode("001-hello-world")

--- a/Tests/ApplicativeRouterTests/ApplicativeRouterTests.swift
+++ b/Tests/ApplicativeRouterTests/ApplicativeRouterTests.swift
@@ -13,10 +13,11 @@ func req(_ method: ApplicativeRouter.Method, _ location: String, _ body: Data? =
 class ApplicativeRouterTests: XCTestCase {
   func testRouter() {
     let router =
-      Route.home <¢ .get <* .end
-        <|> Route.episode <¢> (.get <* lit("episode") *> .str) <* .end
-        <|> Route.episodes <¢ (.get <* lit("episodes")) <* .end
-        <|> Route.search <¢> (.get <* lit("search") *> opt(param("query"))) <* .end
+      Route.home <¢ .get <*| end
+        <|> Route.episode <¢> (.get <* lit("episode") *> .str) <*| end
+        <|> Route.episodes <¢ (.get <* lit("episodes")) <*| end
+        <|> Route.search <¢> (.get <* lit("search") *> opt(param("query"))) <*| end
+        <|> Route.signup <¢> (.post *> .dataBody) <* lit("signup") <*| end
 
     XCTAssertEqual(router.match(req(.get, "/")), .home)
     XCTAssertEqual(router.match(req(.get, "/episodes")), .episodes)
@@ -30,8 +31,8 @@ class ApplicativeRouterTests: XCTestCase {
 
   func testPostData() {
     let router =
-      PostTestRoute.postData <¢> (.post *> .dataBody) <* lit("post") <* .end
-        <|> PostTestRoute.postString <¢> (.post *> .stringBody) <* lit("post") <* .end
+      PostTestRoute.postData <¢> (.post *> .dataBody) <* lit("post") <*| end
+        <|> PostTestRoute.postString <¢> (.post *> .stringBody) <* lit("post") <*| end
 
     XCTAssertNil(router.match(req(.post, "/post", nil)))
 
@@ -41,7 +42,7 @@ class ApplicativeRouterTests: XCTestCase {
 
   func testPostString() {
     let router =
-      PostTestRoute.postString <¢> (.post *> .stringBody) <* lit("post") <* .end
+      PostTestRoute.postString <¢> (.post *> .stringBody) <* lit("post") <*| end
 
     XCTAssertNil(router.match(req(.post, "/post", nil)))
 
@@ -52,7 +53,7 @@ class ApplicativeRouterTests: XCTestCase {
 
   func testPostJsonBody() {
     let router =
-      PostTestRoute.postUser <¢> (.post *> either(.jsonBody, pure("Invalid JSON"))) <* lit("post") <* .end
+      PostTestRoute.postUser <¢> (.post *> either(.jsonBody, pure("Invalid JSON"))) <* lit("post") <*| end
 
     XCTAssertEqual(.postUser(.right("Invalid JSON")), router.match(req(.post, "/post", nil)))
 
@@ -66,6 +67,7 @@ enum Route {
   case episodes
   case episode(String)
   case search(String?)
+  case signup(Data)
 }
 
 extension Route: Equatable {


### PR DESCRIPTION
Indexed generally has `I` and `J` and our parser is only indexed on `I`, so this probably breaks a lot of axioms at the moment. For now unblocking so we can use. Another future option (in lieu of figuring out IxEverything): remove a lil bit of correctness to simplify (_e.g._, let a `GET` parser check for a request body and quietly fail at runtime).