### PR TITLE
Use string literals for the content of script and svg tags

### DIFF
--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -746,6 +746,11 @@ public func width<T: HasWidth>(_ value: Int) -> Attribute<T> {
   return .init("width", value)
 }
 
+public protocol HasXmlns {}
+public func xmlns<T: HasXmlns>(_ value: String) -> Attribute<T> {
+  return .init("xmlns", value)
+}
+
 public enum Wrap: String, Value {
   case hard
   case soft

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -789,7 +789,7 @@ public func samp(_ content: [Node]) -> Node {
   return samp([], content)
 }
 
-public func script(_ attribs: [Attribute<Element.Script>], _ content: StringLiteralType) -> Node {
+public func script(_ attribs: [Attribute<Element.Script>], _ content: StaticString) -> Node {
   return node("script", attribs, [.text(EncodedString(content))])
 }
 
@@ -797,11 +797,11 @@ public func script(_ attribs: [Attribute<Element.Script>]) -> Node {
   return node("script", attribs, [])
 }
 
-public func script(_ content: StringLiteralType) -> Node {
+public func script(_ content: StaticString) -> Node {
   return script([], content)
 }
 
-public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: StringLiteralType) -> ChildOf<T> {
+public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: StaticString) -> ChildOf<T> {
   return .init(script(attribs, content))
 }
 
@@ -809,7 +809,7 @@ public func script<T>(_ attribs: [Attribute<Element.Script>]) -> ChildOf<T> {
   return .init(script(attribs))
 }
 
-public func script<T>(_ content: StringLiteralType) -> ChildOf<T> {
+public func script<T>(_ content: StaticString) -> ChildOf<T> {
   return script([], content)
 }
 
@@ -898,11 +898,11 @@ public func sup(_ content: [Node]) -> Node {
   return sup([], content)
 }
 
-public func svg(_ attribs: [Attribute<Element.Svg>], _ content: StringLiteralType) -> Node {
+public func svg(_ attribs: [Attribute<Element.Svg>], _ content: StaticString) -> Node {
   return node("svg", attribs, [.text(EncodedString(content))])
 }
 
-public func svg(_ content: StringLiteralType) -> Node {
+public func svg(_ content: StaticString) -> Node {
   return node("svg", [.text(EncodedString(content))])
 }
 

--- a/Sources/Html/Elements.swift
+++ b/Sources/Html/Elements.swift
@@ -99,6 +99,7 @@ extension Element {
   public enum Sub {}
   public enum Summary {}
   public enum Sup {}
+  public enum Svg: HasWidth, HasHeight, HasXmlns {}
   public enum Table: ContainsTr {}
   public enum Tbody: ContainsTr {}
   public enum Td: HasColspan, HasHeaders, HasRowspan {}
@@ -788,7 +789,7 @@ public func samp(_ content: [Node]) -> Node {
   return samp([], content)
 }
 
-public func script(_ attribs: [Attribute<Element.Script>], _ content: String) -> Node {
+public func script(_ attribs: [Attribute<Element.Script>], _ content: StringLiteralType) -> Node {
   return node("script", attribs, [.text(EncodedString(content))])
 }
 
@@ -796,11 +797,11 @@ public func script(_ attribs: [Attribute<Element.Script>]) -> Node {
   return node("script", attribs, [])
 }
 
-public func script(_ content: String) -> Node {
+public func script(_ content: StringLiteralType) -> Node {
   return script([], content)
 }
 
-public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: String) -> ChildOf<T> {
+public func script<T>(_ attribs: [Attribute<Element.Script>], _ content: StringLiteralType) -> ChildOf<T> {
   return .init(script(attribs, content))
 }
 
@@ -808,7 +809,7 @@ public func script<T>(_ attribs: [Attribute<Element.Script>]) -> ChildOf<T> {
   return .init(script(attribs))
 }
 
-public func script<T>(_ content: String) -> ChildOf<T> {
+public func script<T>(_ content: StringLiteralType) -> ChildOf<T> {
   return script([], content)
 }
 
@@ -895,6 +896,14 @@ public func sup(_ attribs: [Attribute<Element.Sup>], _ content: [Node]) -> Node 
 
 public func sup(_ content: [Node]) -> Node {
   return sup([], content)
+}
+
+public func svg(_ attribs: [Attribute<Element.Svg>], _ content: StringLiteralType) -> Node {
+  return node("svg", attribs, [.text(EncodedString(content))])
+}
+
+public func svg(_ content: StringLiteralType) -> Node {
+  return node("svg", [.text(EncodedString(content))])
 }
 
 public func table(_ attribs: [Attribute<Element.Table>], _ content: [Node]) -> Node {

--- a/Sources/Html/EncodedString.swift
+++ b/Sources/Html/EncodedString.swift
@@ -6,6 +6,10 @@ public struct EncodedString {
   internal init(_ string: String) {
     self.string = string
   }
+
+  internal init(_ string: StaticString) {
+    self.string = String(describing: string)
+  }
 }
 
 public func + (lhs: EncodedString, rhs: EncodedString) -> EncodedString {

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -59,20 +59,20 @@ public func document(_ content: [Node]) -> Node {
   return .document(content)
 }
 
-public func node<T>(_ name: StringLiteralType, _ attribs: [Attribute<T>], _ content: [Node]?) -> Node {
-  return .element(.init(name: name, attribs: attribs.map(get(\.attrib)), content: content))
+public func node<T>(_ name: StaticString, _ attribs: [Attribute<T>], _ content: [Node]?) -> Node {
+  return .element(.init(name: String(describing: name), attribs: attribs.map(get(\.attrib)), content: content))
 }
 
-public func node(_ name: StringLiteralType, _ content: [Node]?) -> Node {
-  return .element(.init(name: name, attribs: [], content: content))
+public func node(_ name: StaticString, _ content: [Node]?) -> Node {
+  return .element(.init(name: String(describing: name), attribs: [], content: content))
 }
 
 public func text(_ content: String) -> Node {
   return .text(encode(content))
 }
 
-public func attribute<T>(_ name: StringLiteralType, _ value: Value) -> Attribute<T> {
-  return .init(name, value)
+public func attribute<T>(_ name: StaticString, _ value: Value) -> Attribute<T> {
+  return .init(String(describing: name), value)
 }
 
 public func comment(_ content: String) -> Node {

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -75,11 +75,11 @@ public func attribute<T>(_ name: StaticString, _ value: Value) -> Attribute<T> {
   return .init(String(describing: name), value)
 }
 
-public func comment(_ content: String) -> Node {
+public func comment(_ content: StaticString) -> Node {
   return .comment(EncodedString(content))
 }
 
-public func comment<T>(_ content: String) -> ChildOf<T> {
+public func comment<T>(_ content: StaticString) -> ChildOf<T> {
   return .init(comment(content))
 }
 

--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -59,11 +59,11 @@ public func document(_ content: [Node]) -> Node {
   return .document(content)
 }
 
-public func node<T>(_ name: String, _ attribs: [Attribute<T>], _ content: [Node]?) -> Node {
+public func node<T>(_ name: StringLiteralType, _ attribs: [Attribute<T>], _ content: [Node]?) -> Node {
   return .element(.init(name: name, attribs: attribs.map(get(\.attrib)), content: content))
 }
 
-public func node(_ name: String, _ content: [Node]?) -> Node {
+public func node(_ name: StringLiteralType, _ content: [Node]?) -> Node {
   return .element(.init(name: name, attribs: [], content: content))
 }
 
@@ -71,7 +71,7 @@ public func text(_ content: String) -> Node {
   return .text(encode(content))
 }
 
-public func attribute<T>(_ name: String, _ value: Value) -> Attribute<T> {
+public func attribute<T>(_ name: StringLiteralType, _ value: Value) -> Attribute<T> {
   return .init(name, value)
 }
 

--- a/Tests/HtmlTests/FullDocumentTests.swift
+++ b/Tests/HtmlTests/FullDocumentTests.swift
@@ -19,25 +19,30 @@ class FullDocumentTests: XCTestCase {
               body % (
                 background(Color.rgb(240, 240, 240))
               )
-            )
+            ),
+            script("alert(\"hello world!\")")
           ]
         ),
         body(
-          [ Html.class <| "home",
-            id <| "home"
-          ],
+          [ Html.class("home"), id("home") ],
           [
             header(
-              [ Html.class <| "site-header" ],
+              [ Html.class("site-header") ],
               [
-                a([ href <| "/home" ], [ "Home" ]),
+                svg(
+                  [xmlns("http://www.w3.org/2000/svg"), width(100), height(100)],
+                  """
+<circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+"""
+                ),
+                a([ href("/home") ], [ "Home" ]),
                 nav(
-                  [ Html.class <| "site-nav" ],
+                  [ Html.class("site-nav") ],
                   [
                     div(
                       [
-                        a([href <| "/episodes"], ["Episodes"]),
-                        a([href <| "/About"], ["About"]),
+                        a([href("/episodes")], ["Episodes"]),
+                        a([href("/About")], ["About"]),
                       ]
                     )
                   ]
@@ -46,33 +51,33 @@ class FullDocumentTests: XCTestCase {
             ),
 
             main(
-              [ Html.class <| "page-content" ],
+              [ Html.class("page-content") ],
               [
                 h1(
-                  [ Html.class <| "page-heading" ],
+                  [ Html.class("page-heading") ],
                   [
                     ul(
-                      [ Html.class <| "episode-list" ],
+                      [ Html.class("episode-list") ],
                       [
                         li(
                           [
                             span(
-                              [ Html.class <| "episode-metadata" ],
+                              [ Html.class("episode-metadata") ],
                               [ "April 27, 2017" ]
                             ),
                             h2(
-                              [ a([href <| "/episode/2"], ["Episode #2"]) ]
+                              [ a([href("/episode/2")], ["Episode #2"]) ]
                             )
                           ]
                         ),
                         li(
                           [
                             span(
-                              [ Html.class <| "episode-metadata" ],
+                              [ Html.class("episode-metadata") ],
                               [ "April 20, 2017" ]
                             ),
                             h2(
-                              [ a([href <| "/episode/1"], ["Episode #1"]) ]
+                              [ a([href("/episode/1")], ["Episode #1"]) ]
                             )
                           ]
                         ),
@@ -81,11 +86,11 @@ class FullDocumentTests: XCTestCase {
                   ]
                 ),
                 p(
-                  [ Html.class <| "rss-subscribe" ],
+                  [ Html.class("rss-subscribe") ],
                   [
                     "subscribe ",
                     a(
-                      [ href <| "/rss.xml" ],
+                      [ href("/rss.xml") ],
                       [ "via RSS" ]
                     )
                   ]
@@ -94,27 +99,28 @@ class FullDocumentTests: XCTestCase {
             ),
 
             footer(
-              [ Html.class <| "site-footer" ],
+              [ Html.class("site-footer") ],
               [
                 h2(["The Site"]),
                 ul(
                   [
-                    li([a([href <| "#"], ["Contact us"])]),
-                    li([a([href <| "#"], ["About"])]),
-                    li([a([href <| "#"], ["Home"])]),
+                    li([a([href("#")], ["Contact us"])]),
+                    li([a([href("#")], ["About"])]),
+                    li([a([href("#")], ["Home"])]),
                   ]
                 ),
                 form(
-                  [ id <| "newsletter-form", action <| "#", Html.method <| .post ],
+                  [ id("newsletter-form"), action("#"), Html.method(.post) ],
                   [
                     h4(["Sign up for our newsletter!"]),
-                    label([Html.for <| "email"], ["Email: "]),
-                    input([type <| .text, Html.name <| "email", id <| "email", Html.value <| ""]),
-                    input([type <| .submit, Html.value <| "Submit"])
+                    label([Html.for("email")], ["Email: "]),
+                    input([type(.text), Html.name("email"), id("email"), Html.value("")]),
+                    input([type(.submit), Html.value("Submit")])
                   ]
                 )
               ]
-            )
+            ),
+            script("/* google analytics */")
           ]
         )
       ]

--- a/Tests/HtmlTests/__Snapshots__/FullDocumentTests/testDocument.1.html
+++ b/Tests/HtmlTests/__Snapshots__/FullDocumentTests/testDocument.1.html
@@ -6,9 +6,15 @@
     <style>
       body{background:#f0f0f0}
     </style>
+    <script>
+      alert("hello world!")
+    </script>
   </head>
   <body class="home" id="home">
     <header class="site-header">
+      <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+        <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+      </svg>
       <a href="/home">
         Home
       </a>
@@ -87,5 +93,8 @@
         <input type="submit" value="Submit">
       </form>
     </footer>
+    <script>
+      /* google analytics */
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This at least limits security vulnerabilities to the user of the lib putting in an unsafe literal string.