### PR TITLE
Added routing middleware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,8 @@ let package = Package(
   name: "Web",
   products: [
     .library(name: "ApplicativeRouter", targets: ["ApplicativeRouter"]),
+    .library(name: "ApplicativeRouterHttpPipelineSupport",
+             targets: ["ApplicativeRouterHttpPipelineSupport"]),
     .library(name: "Css", targets: ["Css"]),
     .library(name: "CssReset", targets: ["CssReset"]),
     .library(name: "CssTestSupport", targets: ["CssTestSupport"]),
@@ -26,6 +28,11 @@ let package = Package(
   targets: [
     .target(name: "ApplicativeRouter", dependencies: ["Either", "Prelude"]),
     .testTarget(name: "ApplicativeRouterTests", dependencies: ["ApplicativeRouter", "Optics"]),
+
+    .target(name: "ApplicativeRouterHttpPipelineSupport",
+            dependencies: ["ApplicativeRouter", "HttpPipeline", "Prelude"]),
+    .testTarget(name: "ApplicativeRouterHttpPipelineSupportTests",
+                dependencies: ["ApplicativeRouterHttpPipelineSupport", "HttpPipelineTestSupport", "SnapshotTesting"]),
 
     .target(name: "Css", dependencies: ["Either", "Prelude"]),
     .testTarget(name: "CssTests", dependencies: ["Css", "CssTestSupport"]),

--- a/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
+++ b/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
@@ -3,6 +3,12 @@ import Foundation
 import HttpPipeline
 import Prelude
 
+/// Middleware transformer that performs routing via a router, and if a route is unrecognized runs the
+/// `notFound` middleware supplied.
+///
+/// - Parameters:
+///   - router: A router from `ApplicativeRouter`.
+///   - notFound: Middleware to run if a route is not recognized.
 public func route<I, A, Route>(
   router: Parser<I, Route>,
   notFound: @escaping Middleware<StatusLineOpen, ResponseEnded, A, Data?> = notFound(respond(text: "don't know that url"))

--- a/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
+++ b/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
@@ -1,0 +1,21 @@
+import ApplicativeRouter
+import Foundation
+import HttpPipeline
+import Prelude
+
+public func route<I, A, Route>(
+  router: Parser<I, Route>,
+  notFound: @escaping Middleware<StatusLineOpen, ResponseEnded, A, Data?> = notFound(respond(text: "don't know that url"))
+  )
+  -> (@escaping Middleware<StatusLineOpen, ResponseEnded, Route, Data?>)
+  -> Middleware<StatusLineOpen, ResponseEnded, A, Data?> {
+
+    return { middleware in
+      return { conn in
+
+        router.match(conn.request)
+          .map(const >>> conn.map >>> middleware)
+          ?? notFound(conn)
+      }
+    }
+}

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
@@ -1,0 +1,58 @@
+import ApplicativeRouter
+import ApplicativeRouterHttpPipelineSupport
+import HttpPipeline
+import HttpPipelineTestSupport
+import Prelude
+import SnapshotTesting
+import XCTest
+
+class ApplicativeRouterHttpPipelineSupportTests: XCTestCase {
+  func testRoute() {
+    let router =
+      Route.home <¢ .get <*| end
+        <|> Route.episode <¢> (.get <* lit("episode") *> .str) <*| end
+
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+      route(router: router)
+        <| (
+          writeStatus(.ok)
+            >>> { $0 |> respond(text: "Recognized route: \($0.data)") }
+    )
+
+    assertSnapshot(
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/")!))),
+      named: "home"
+    )
+
+    assertSnapshot(
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/episode/ep1-hello-world")!))),
+      named: "episode"
+    )
+
+    assertSnapshot(
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))),
+      named: "unrecognized"
+    )
+  }
+
+  func testRoute_UnrecognizedWithCustomNotFound() {
+    let router = Route.home <¢ .get <*| end
+
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+      route(router: router, notFound: notFound(respond(text: "Unrecognized route!")))
+        <| (
+          writeStatus(.ok)
+            >>> { $0 |> respond(text: "Recognized route: \($0.data)") }
+    )
+
+    assertSnapshot(
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))),
+      named: "unrecognized"
+    )
+  }
+}
+
+enum Route {
+  case home
+  case episode(String)
+}

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.1.home.Conn.txt
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.1.home.Conn.txt
@@ -1,0 +1,14 @@
+▿ Step
+  ResponseEnded
+
+▿ Request
+  GET /
+
+  (Data, 0 bytes)
+
+▿ Response
+  Status 200 OK
+  Content-Length: 22
+  Content-Type: text/plain
+
+  Recognized route: home

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.2.episode.Conn.txt
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.2.episode.Conn.txt
@@ -1,0 +1,14 @@
+▿ Step
+  ResponseEnded
+
+▿ Request
+  GET /episode/ep1-hello-world
+
+  (Data, 0 bytes)
+
+▿ Response
+  Status 200 OK
+  Content-Length: 44
+  Content-Type: text/plain
+
+  Recognized route: episode("ep1-hello-world")

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.3.unrecognized.Conn.txt
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.3.unrecognized.Conn.txt
@@ -1,0 +1,14 @@
+▿ Step
+  ResponseEnded
+
+▿ Request
+  GET /does/not/exist
+
+  (Data, 0 bytes)
+
+▿ Response
+  Status 404 NOT FOUND
+  Content-Length: 19
+  Content-Type: text/plain
+
+  don't know that url

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute_UnrecognizedWithCustomNotFound.1.unrecognized.Conn.txt
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute_UnrecognizedWithCustomNotFound.1.unrecognized.Conn.txt
@@ -1,0 +1,14 @@
+▿ Step
+  ResponseEnded
+
+▿ Request
+  GET /does/not/exist
+
+  (Data, 0 bytes)
+
+▿ Response
+  Status 404 NOT FOUND
+  Content-Length: 19
+  Content-Type: text/plain
+
+  Unrecognized route!


### PR DESCRIPTION
One last piece of middleware transformer I forgot from my last PR #55. This takes a router, some not found middleware, and does the routing.

I added this to a package `ApplicativeRouterHttpPipelineSupport` that depends on each the router and pipeline.