### PR TITLE
[Proof of concept] Make middleware go `(Conn) -> IO<Conn>`

### DIFF
--- a/Sources/HttpPipeline/Conn.swift
+++ b/Sources/HttpPipeline/Conn.swift
@@ -36,6 +36,12 @@ public func flatMap<Step, A, B>(_ f: @escaping (A) -> Conn<Step, B>) -> (Conn<St
   return { $0.flatMap(f) }
 }
 
+extension Conn {
+  public static func >>- <B>(_ x: Conn, f: @escaping (Data) -> Conn<Step, B>) -> Conn<Step, B> {
+    return x.flatMap(f)
+  }
+}
+
 public func connection(from request: URLRequest) -> Conn<StatusLineOpen, Prelude.Unit> {
   return .init(
     data: unit,

--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -16,11 +16,11 @@ public func writeStatus<A>(_ status: Status) -> Middleware<StatusLineOpen, Heade
 }
 
 public func writeHeader<A>(_ header: ResponseHeader) -> Middleware<HeadersOpen, HeadersOpen, A, A> {
-  return (\.response.headers %~ { $0 + [header] }) >>> pure
+  return pure <<< (\.response.headers %~ { $0 + [header] })
 }
 
 public func writeHeaders<A>(_ headers: [ResponseHeader]) -> Middleware<HeadersOpen, HeadersOpen, A, A> {
-  return (\.response.headers %~ { $0 + headers }) >>> pure
+  return pure <<< (\.response.headers %~ { $0 + headers }) 
 }
 
 public func writeHeader<A>(_ name: String, _ value: String) -> Middleware<HeadersOpen, HeadersOpen, A, A> {

--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -6,13 +6,11 @@ import Prelude
 public typealias Middleware<I, J, A, B> = (Conn<I, A>) -> IO<Conn<J, B>>
 
 public func writeStatus<A>(_ status: Status) -> Middleware<StatusLineOpen, HeadersOpen, A, A> {
-  return { conn in
-    pure(
-      .init(
-        data: conn.data,
-        request: conn.request,
-        response: conn.response |> \.status .~ status
-      )
+  return pure <<< { conn in
+    .init(
+      data: conn.data,
+      request: conn.request,
+      response: conn.response |> \.status .~ status
     )
   }
 }
@@ -30,38 +28,30 @@ public func writeHeader<A>(_ name: String, _ value: String) -> Middleware<Header
 }
 
 public func closeHeaders<A>(conn: Conn<HeadersOpen, A>) -> IO<Conn<BodyOpen, A>> {
-  return pure(
-    .init(
-      data: conn.data,
-      request: conn.request,
-      response: conn.response
-    )
+  return pure <| .init(
+    data: conn.data,
+    request: conn.request,
+    response: conn.response
   )
 }
 
 public func end(conn: Conn<BodyOpen, Data?>) -> IO<Conn<ResponseEnded, Data?>> {
-  return pure(
-    .init(
-      data: conn.data,
-      request: conn.request,
-      response: Response(
-        status: conn.response.status,
-        headers: conn.response.headers,
-        body: conn.data
-      )
+  return pure <| .init(
+    data: conn.data,
+    request: conn.request,
+    response: Response(
+      status: conn.response.status,
+      headers: conn.response.headers,
+      body: conn.data
     )
   )
 }
 
 public func end<A>(conn: Conn<HeadersOpen, A>) -> IO<Conn<ResponseEnded, Data?>> {
   return conn
-    |> (
-      closeHeaders
-        >-> map(const(nil))
-        >>> pure
-        >-> end
-  )
-
+    |> closeHeaders
+    >-> map(const(nil)) >>> pure
+    >-> end
 }
 
 public func redirect<A>(
@@ -86,15 +76,13 @@ public func send(_ data: Data?) -> Middleware<BodyOpen, BodyOpen, Data?, Data?> 
     var concatenatedData = conn.data ?? Data()
     data.do { concatenatedData.append($0) }
 
-    return pure(
-      .init(
-        data: concatenatedData,
-        request: conn.request,
-        response: Response(
-          status: conn.response.status,
-          headers: conn.response.headers,
-          body: concatenatedData
-        )
+    return pure <| .init(
+      data: concatenatedData,
+      request: conn.request,
+      response: Response(
+        status: conn.response.status,
+        headers: conn.response.headers,
+        body: concatenatedData
       )
     )
   }
@@ -115,8 +103,7 @@ public func respond<A>(json: String) -> Middleware<HeadersOpen, ResponseEnded, A
 public func respond<A>(body: String, contentType: MediaType)
   -> Middleware<HeadersOpen, ResponseEnded, A, Data?> {
     let data = body.data(using: .utf8)
-    return map(const(data))
-      >>> pure
+    return map(const(data)) >>> pure
       >-> writeHeader(.contentType(contentType))
       >-> writeHeader(.contentLength(data?.count ?? 0))
       >-> closeHeaders

--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -47,6 +47,7 @@ public func end(conn: Conn<BodyOpen, Data?>) -> IO<Conn<ResponseEnded, Data?>> {
   )
 }
 
+// TODO: rename to ignoreBody
 public func end<A>(conn: Conn<HeadersOpen, A>) -> IO<Conn<ResponseEnded, Data?>> {
   return conn
     |> closeHeaders

--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -20,7 +20,7 @@ public func writeHeader<A>(_ header: ResponseHeader) -> Middleware<HeadersOpen, 
 }
 
 public func writeHeaders<A>(_ headers: [ResponseHeader]) -> Middleware<HeadersOpen, HeadersOpen, A, A> {
-  return pure <<< (\.response.headers %~ { $0 + headers }) 
+  return pure <<< (\.response.headers %~ { $0 + headers })
 }
 
 public func writeHeader<A>(_ name: String, _ value: String) -> Middleware<HeadersOpen, HeadersOpen, A, A> {
@@ -64,8 +64,7 @@ public func redirect<A>(
     return writeStatus(.found)
       >-> headersMiddleware
       >-> writeHeader(.location(location))
-      >-> map(const(nil))
-      >>> pure
+      >-> map(const(nil)) >>> pure
       >-> closeHeaders
       >-> end
 }

--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -64,8 +64,6 @@ public func redirect<A>(
     return writeStatus(.found)
       >-> headersMiddleware
       >-> writeHeader(.location(location))
-      >-> map(const(nil)) >>> pure
-      >-> closeHeaders
       >-> end
 }
 

--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -107,8 +107,6 @@ public func redirectUnrelatedHosts<A>(
             conn
               |> writeStatus(.movedPermanently)
               >-> writeHeader(.location($0.absoluteString))
-              >-> map(const(nil)) >>> pure
-              >-> closeHeaders
               >-> end
           }
           ?? middleware(conn)
@@ -134,8 +132,6 @@ public func requireHerokuHttps<A>(allowedInsecureHosts: [String])
             conn
               |> writeStatus(.movedPermanently)
               >-> writeHeader(.location($0.absoluteString))
-              >-> map(const(nil)) >>> pure
-              >-> closeHeaders
               >-> end
           }
           ?? middleware(conn)
@@ -159,8 +155,6 @@ public func requireHttps<A>(allowedInsecureHosts: [String])
             conn
               |> writeStatus(.movedPermanently)
               >-> writeHeader(.location($0.absoluteString))
-              >-> map(const(nil)) >>> pure
-              >-> closeHeaders
               >-> end
           }
           ?? middleware(conn)

--- a/Sources/HttpPipelineHtmlSupport/Support.swift
+++ b/Sources/HttpPipelineHtmlSupport/Support.swift
@@ -7,8 +7,7 @@ public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded
   
   return
     map { view.rendered(with: $0).data(using: .utf8) }
-      >>> pure
-      >-> writeHeader(.contentType(.html))
+      >>> writeHeader(.contentType(.html))
       >-> closeHeaders
       >-> end
 }

--- a/Sources/HttpPipelineHtmlSupport/Support.swift
+++ b/Sources/HttpPipelineHtmlSupport/Support.swift
@@ -4,10 +4,11 @@ import HttpPipeline
 import Prelude
 
 public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded, A, Data?> {
-
-  return map(view.rendered(with:))
-    >>> map { $0.data(using: .utf8) }
-    >>> writeHeader(.contentType(.html))
-    >>> closeHeaders
-    >>> end
+  
+  return
+    map { view.rendered(with: $0).data(using: .utf8) }
+      >>> pure
+      >-> writeHeader(.contentType(.html))
+      >-> closeHeaders
+      >-> end
 }

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
@@ -14,23 +14,21 @@ class ApplicativeRouterHttpPipelineSupportTests: XCTestCase {
 
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       route(router: router)
-        <| (
-          writeStatus(.ok)
-            >>> { $0 |> respond(text: "Recognized route: \($0.data)") }
-    )
+        <| writeStatus(.ok)
+        >-> { $0 |> respond(text: "Recognized route: \($0.data)") }
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "/")!))),
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/")!))).perform(),
       named: "home"
     )
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "/episode/ep1-hello-world")!))),
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/episode/ep1-hello-world")!))).perform(),
       named: "episode"
     )
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))),
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))).perform(),
       named: "unrecognized"
     )
   }
@@ -40,13 +38,11 @@ class ApplicativeRouterHttpPipelineSupportTests: XCTestCase {
 
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       route(router: router, notFound: notFound(respond(text: "Unrecognized route!")))
-        <| (
-          writeStatus(.ok)
-            >>> { $0 |> respond(text: "Recognized route: \($0.data)") }
-    )
+        <| writeStatus(.ok)
+        >-> { $0 |> respond(text: "Recognized route: \($0.data)") }
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))),
+      matching: middleware(connection(from: URLRequest(url: URL(string: "/does/not/exist")!))).perform(),
       named: "unrecognized"
     )
   }

--- a/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
+++ b/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
@@ -8,9 +8,10 @@ class HttpPipelineHtmlSupportTests: XCTestCase {
   func testResponse() {
     let view = View<Prelude.Unit> { _ in p(["Hello world!"]) }
     let pipeline = writeStatus(.ok)
-      >>> respond(view)
+      >-> respond(view)
+
     let conn = connection(from: URLRequest(url: URL(string: "/")!))
-    let response = conn |> pipeline
+    let response = (conn |> pipeline).perform()
 
     XCTAssertEqual(200, response.response.status.rawValue)
     XCTAssertEqual(

--- a/Tests/HttpPipelineTests/HttpPipelineTests.swift
+++ b/Tests/HttpPipelineTests/HttpPipelineTests.swift
@@ -19,15 +19,15 @@ class HttpPipelineTests: XCTestCase {
   func testHtmlResponse() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       writeStatus(.ok)
-        >>> respond(html: "<p>Hello, world</p>")
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testRedirect() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> = redirect(to: "/sign-in")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testRedirect_AdditionalHeaders() {
@@ -40,42 +40,42 @@ class HttpPipelineTests: XCTestCase {
   func testWriteHeaders() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       writeStatus(.ok)
-        >>> writeHeader("Z", "Header should be last")
-        >>> writeHeader("Hello", "World")
-        >>> writeHeader("Goodbye", "World")
-        >>> writeHeader("A", "Header should be first")
-        >>> respond(html: "<p>Hello, world</p>")
+        >-> writeHeader("Z", "Header should be last")
+        >-> writeHeader("Hello", "World")
+        >-> writeHeader("Goodbye", "World")
+        >-> writeHeader("A", "Header should be first")
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testCookies() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       writeStatus(.ok)
-        >>> writeHeader(.setCookie(key: "user_id", value: "123456", options: []))
-        >>> writeHeader(.setCookie(key: "lang", value: "es", options: []))
-        >>> writeHeader(.clearCookie(key: "test"))
-        >>> respond(html: "<p>Hello, world</p>")
+        >-> writeHeader(.setCookie(key: "user_id", value: "123456", options: []))
+        >-> writeHeader(.setCookie(key: "lang", value: "es", options: []))
+        >-> writeHeader(.clearCookie(key: "test"))
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testCookieOptions() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       writeStatus(.ok)
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.domain("www.pointfree.co")]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.expires(1234567890)]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.httpOnly]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.maxAge(3600)]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.path("/path/to/some/where")]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.sameSite(.lax)]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.sameSite(.strict)]))
-        >>> writeHeader(.setCookie(key: "foo", value: "bar", options: [.secure]))
-        >>> writeHeader(
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.domain("www.pointfree.co")]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.expires(1234567890)]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.httpOnly]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.maxAge(3600)]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.path("/path/to/some/where")]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.sameSite(.lax)]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.sameSite(.strict)]))
+        >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.secure]))
+        >-> writeHeader(
           .setCookie(key: "foo", value: "bar", options: [.domain("www.pointfree.co"), .httpOnly, .secure])
         )
-        >>> respond(html: "<p>Hello, world</p>")
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 }

--- a/Tests/HttpPipelineTests/HttpPipelineTests.swift
+++ b/Tests/HttpPipelineTests/HttpPipelineTests.swift
@@ -34,7 +34,7 @@ class HttpPipelineTests: XCTestCase {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       redirect(to: "/sign-in", headersMiddleware: writeHeader("Pass-through", "hello!"))
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testWriteHeaders() {

--- a/Tests/HttpPipelineTests/HttpPipelineTests.swift
+++ b/Tests/HttpPipelineTests/HttpPipelineTests.swift
@@ -11,9 +11,9 @@ class HttpPipelineTests: XCTestCase {
   func testPipeline() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       writeStatus(.ok)
-        >>> respond(text: "Hello, world")
+        >-> respond(text: "Hello, world")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testHtmlResponse() {

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -11,17 +11,19 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   func testBasicAuth_Unauthorized() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       basicAuth(user: "Hello", password: "World")
-        <| writeStatus(.ok) >>> respond(html: "<p>Hello, world</p>")
+        <| writeStatus(.ok)
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testBasicAuth_Unauthorized_Realm() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       basicAuth(user: "Hello", password: "World", realm: "Point-Free")
-        <| writeStatus(.ok) >>> respond(html: "<p>Hello, world</p>")
+        <| writeStatus(.ok)
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testBasicAuth_Unauthorized_CustomFailure() {
@@ -31,35 +33,37 @@ class SharedMiddlewareTransformersTests: XCTestCase {
         password: "World",
         failure: respond(text: "Custom authentication page!")
         )
-        <| writeStatus(.ok) >>> respond(html: "<p>Hello, world</p>")
+        <| writeStatus(.ok)
+        >-> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testBasicAuth_Authorized() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       basicAuth(user: "Hello", password: "World")
-        <| writeStatus(.ok) >>> respond(html: "<p>Hello, world</p>")
+        <| writeStatus(.ok)
+        >-> respond(html: "<p>Hello, world</p>")
 
     let conn = connection(
       from: URLRequest(url: URL(string: "/")!)
         |> \.allHTTPHeaderFields .~ ["Authorization": "Basic SGVsbG86V29ybGQ="]
     )
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testContentLengthMiddlewareTransformer() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       contentLength
         <| writeStatus(.ok)
-        >>> writeHeader(.contentType(.html))
-        >>> closeHeaders
-        >>> map(const(Data()))
-        >>> send("<p>Hello, world</p>".data(using: .utf8))
-        >>> end
+        >-> writeHeader(.contentType(.html))
+        >-> closeHeaders
+        >-> map(const(Data())) >>> pure
+        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> end
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testRedirectUnrelatedHosts() {
@@ -73,23 +77,23 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       redirectUnrelatedHosts(allowedHosts: allowedHosts, canonicalHost: "www.pointfree.co")
         <| writeStatus(.ok)
-        >>> writeHeader(.contentType(.html))
-        >>> closeHeaders
-        >>> map(const(Data()))
-        >>> send("<p>Hello, world</p>".data(using: .utf8))
-        >>> end
+        >-> writeHeader(.contentType(.html))
+        >-> closeHeaders
+        >-> map(const(Data())) >>> pure
+        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> end
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://pointfree.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.point-free.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.point-free.co")!))).perform()
     )
   }
 
@@ -103,11 +107,11 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       requireHerokuHttps(allowedInsecureHosts: allowedInsecureHosts)
         <| writeStatus(.ok)
-        >>> writeHeader(.contentType(.html))
-        >>> closeHeaders
-        >>> map(const(Data()))
-        >>> send("<p>Hello, world</p>".data(using: .utf8))
-        >>> end
+        >-> writeHeader(.contentType(.html))
+        >-> closeHeaders
+        >-> map(const(Data())) >>> pure
+        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> end
 
     func securedConnection(from request: URLRequest) -> Conn<StatusLineOpen, Prelude.Unit> {
       var result = request
@@ -117,13 +121,13 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     }
 
     assertSnapshot(
-      matching: middleware(securedConnection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!)))
+      matching: middleware(securedConnection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!))).perform()
     )
   }
 
@@ -137,20 +141,20 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       requireHttps(allowedInsecureHosts: allowedInsecureHosts)
         <| writeStatus(.ok)
-        >>> writeHeader(.contentType(.html))
-        >>> closeHeaders
-        >>> map(const(Data()))
-        >>> send("<p>Hello, world</p>".data(using: .utf8))
-        >>> end
+        >-> writeHeader(.contentType(.html))
+        >-> closeHeaders
+        >-> map(const(Data())) >>> pure
+        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> end
 
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!))).perform()
     )
     assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!)))
+      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!))).perform()
     )
   }
 }

--- a/Tests/HttpPipelineTests/SignedCookieTests.swift
+++ b/Tests/HttpPipelineTests/SignedCookieTests.swift
@@ -20,12 +20,12 @@ aGVsbG8td29ybGQ=\
 
     let middleware: Middleware<StatusLineOpen, HeadersOpen, Prelude.Unit, Prelude.Unit> =
       writeStatus(.ok)
-        >>> writeHeaders(
+        >-> writeHeaders(
           [.setSignedCookie(key: "session", value: "hello-world", secret: secret)]
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
 
     XCTAssertEqual(
       "hello-world",
@@ -51,12 +51,12 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
 
     let middleware: Middleware<StatusLineOpen, HeadersOpen, Prelude.Unit, Prelude.Unit> =
       writeStatus(.ok)
-        >>> writeHeaders(
+        >-> writeHeaders(
           [.setSignedCookie(key: "session", value: episode, secret: secret)]
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
 
     XCTAssertEqual(
       episode,
@@ -82,12 +82,12 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
 
     let middleware: Middleware<StatusLineOpen, HeadersOpen, Prelude.Unit, Prelude.Unit> =
       writeStatus(.ok)
-        >>> writeHeaders(
+        >-> writeHeaders(
           [.setSignedCookie(key: "session", value: "hello-world", secret: secret, encrypt: true)]
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
 
     XCTAssertEqual(
       "hello-world",
@@ -120,12 +120,12 @@ cb4db8ac9390ac810837809f11bc6803\
 
     let middleware: Middleware<StatusLineOpen, HeadersOpen, Prelude.Unit, Prelude.Unit> =
       writeStatus(.ok)
-        >>> writeHeaders(
+        >-> writeHeaders(
           [.setSignedCookie(key: "session", value: episode, secret: secret, encrypt: true)]
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn))
+    assertSnapshot(matching: middleware(conn).perform())
 
     XCTAssertEqual(
       episode,


### PR DESCRIPTION
We've talked about this IRL, so I wanted to give it a shot. I changed `Middleware<I, J, A, B>` to be functions `(Conn<I, A>) -> IO<Conn<J, B>>` so that all middleware can do side effects in `IO`. This will help with composition in point free since right now we have a weird hodgepodge of middleware that returns pure `Conn`'s and `IO<Conn>`'s.

it does add some complexity tho! so wanna think it through. whatdya think?