### PR TITLE
Parameter to control basic auth from predicarte.

### DIFF
--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -102,7 +102,7 @@ public func requireHerokuHttps<A>(allowedInsecureHosts: [String])
     return { middleware in
       return { conn in
         conn.request.url
-          .filterOptional { (url: URL) -> Bool in
+          .filterOptional { url in
             // `url.scheme` cannot be trusted on Heroku, instead we need to look at the `X-Forwarded-Proto`
             // header to determine if we are on https or not.
             conn.request.allHTTPHeaderFields?["X-Forwarded-Proto"] != .some("https")

--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -3,50 +3,31 @@ import Optics
 import Prelude
 
 /// Wraps basic auth middleware around existing middleware. Provides only the most basic of authentication
-/// where the username and password are static, e.g. we do not look in a database for the user. If
-/// authentication fails a basic "Please authenticate." html page will be rendered.
-///
-/// - Parameters:
-///   - user: The user name to authenticate against.
-///   - password: The password to authenticate against.
-/// - Returns: Transformed middleware
-public func basicAuth<A>(
-  user: String,
-  password: String,
-  realm: String? = nil
-  )
-  -> (@escaping Middleware<StatusLineOpen, ResponseEnded, A, Data?>)
-  -> Middleware<StatusLineOpen, ResponseEnded, A, Data?> {
-
-    return basicAuth(
-      user: user,
-      password: password,
-      realm: realm,
-      failure: respond(text: "Please authenticate.")
-    )
-}
-
-/// Wraps basic auth middleware around existing middleware. Provides only the most basic of authentication
 /// where the username and password are static, e.g. we do not look in a database for the user.
 ///
 /// - Parameters:
 ///   - user: The user name to authenticate against.
 ///   - password: The password to authenticate against.
-///   - failure: The middleware to run in the case that authentication fails.
+///   - realm: The realm.
+///   - protect: An optional predicate that can further control what values of `A` are protected by basic auth.
+///   - failure: An optional middleware to run in the case that authentication fails.
 /// - Returns: Transformed middleware
 public func basicAuth<A>(
   user: String,
   password: String,
   realm: String? = nil,
-  failure: @escaping Middleware<HeadersOpen, ResponseEnded, A, Data?>
+  protect: @escaping (A) -> Bool = const(true),
+  failure: @escaping Middleware<HeadersOpen, ResponseEnded, A, Data?> = respond(text: "Please authenticate.")
   )
   -> (@escaping Middleware<StatusLineOpen, ResponseEnded, A, Data?>)
   -> Middleware<StatusLineOpen, ResponseEnded, A, Data?> {
 
     return { middleware in
       return { conn in
-        if validateBasicAuth(user: user, password: password, request: conn.request) {
-          return middleware(conn)
+        guard protect(conn.data)
+          && !validateBasicAuth(user: user, password: password, request: conn.request)
+          else {
+            return middleware(conn)
         }
 
         return conn |>

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -17,6 +17,15 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     assertSnapshot(matching: middleware(conn).perform())
   }
 
+  func testBasicAuth_Unauthorized_ProtectedPredicate() {
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+      basicAuth(user: "Hello", password: "World", protect: const(false))
+        <| writeStatus(.ok)
+        >-> respond(html: "<p>Hello, world</p>")
+
+    assertSnapshot(matching: middleware(conn).perform())
+  }
+
   func testBasicAuth_Unauthorized_Realm() {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
       basicAuth(user: "Hello", password: "World", realm: "Point-Free")

--- a/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Unauthorized_ProtectedPredicate.1.Conn.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Unauthorized_ProtectedPredicate.1.Conn.txt
@@ -1,0 +1,14 @@
+▿ Step
+  ResponseEnded
+
+▿ Request
+  GET /
+
+  (Data, 0 bytes)
+
+▿ Response
+  Status 200 OK
+  Content-Length: 19
+  Content-Type: text/html; charset=utf8
+
+  <p>Hello, world</p>


### PR DESCRIPTION
In something Im working on I wanna be able to control the basic auth based on a predicate on `A`. so adding it as an optional param. also removed an overload of `basicAuth` that I don't think is important.