### PR TITLE
URL form encoding

### DIFF
--- a/Sources/HttpPipeline/UrlFormEncoding.swift
+++ b/Sources/HttpPipeline/UrlFormEncoding.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Prelude
+
+/// Encodes an encodable into `x-www-form-urlencoded` format. It first converts the value into a JSON
+/// dictionary, and then it encodes that into the format.
+///
+/// - Parameter value: The encodable value to encode.
+public func urlFormEncode<A: Encodable>(value: A) -> String {
+
+  return (try? JSONEncoder().encode(value))
+    .flatMap { try? JSONSerialization.jsonObject(with: $0) }
+    .flatMap { $0 as? [String: Any] }
+    .map(urlFormEncode(value:))
+    ?? ""
+}
+
+/// Encodes an array into `x-www-form-urlencoded` format.
+///
+/// - Parameters:
+///   - value: The array of values to encode.
+///   - rootKey: A root key to hold the array.
+public func urlFormEncode(values: [Any], rootKey: String) -> String {
+  return urlFormEncode(values: values, rootKey: rootKey, keyConstructor: id)
+}
+
+/// Encodes a dictionary of values into `x-www-form-urlencoded` format.
+///
+/// - Parameter value: The dictionary of values to encode
+public func urlFormEncode(value: [String: Any]) -> String {
+  return urlFormEncode(value: value, keyConstructor: id)
+}
+
+// MARK: - Private
+
+private func urlFormEncode(values: [Any], rootKey: String, keyConstructor: (String) -> String) -> String {
+  return values.enumerated()
+    .map { idx, value in
+      switch value {
+      case let value as [String: Any]:
+        return urlFormEncode(value: value, keyConstructor: { "\(keyConstructor(rootKey))[\(idx)][\($0)]" })
+
+      case let values as [Any]:
+        return urlFormEncode(
+          values: values, rootKey: "", keyConstructor: { _ in "\(keyConstructor(rootKey))[\(idx)]" }
+        )
+
+      default:
+        return urlFormEncode(value: value, keyConstructor: { _ in "\(keyConstructor(rootKey))[\(idx)]" })
+      }
+    }
+    .joined(separator: "&")
+}
+
+private func urlFormEncode(value: Any, keyConstructor: (String) -> String) -> String {
+  guard let dictionary = value as? [String: Any] else {
+    let encoded = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryParamAllowed) ?? value
+    return "\(keyConstructor(""))=\(encoded)"
+  }
+
+  return dictionary
+    .map { key, value in
+      switch value {
+      case let value as [String: Any]:
+        return urlFormEncode(value: value, keyConstructor: { "\(keyConstructor(key))[\($0)]" })
+
+      case let values as [Any]:
+        return urlFormEncode(values: values, rootKey: key, keyConstructor: keyConstructor)
+
+      default:
+        return urlFormEncode(value: value, keyConstructor: { _ in keyConstructor(key) })
+      }
+    }
+    .joined(separator: "&")
+}
+
+extension CharacterSet {
+  public static let urlQueryParamAllowed = CharacterSet(charactersIn: "?=&# ").inverted
+}

--- a/Tests/HttpPipelineTests/UrlFormEncodingTests.swift
+++ b/Tests/HttpPipelineTests/UrlFormEncodingTests.swift
@@ -1,0 +1,85 @@
+import HttpPipeline
+import HttpPipelineTestSupport
+import Optics
+import Prelude
+import SnapshotTesting
+import XCTest
+
+final class UrlFormEncoderTests: XCTestCase {
+  func testEncoding_DeepObject() {
+    assertSnapshot(
+      matching: urlFormEncode(
+        value: [
+          "id": 42,
+          "name": "Blob McBlob",
+          "bio": "!*'();:@&=+$,/?%#[] ^",
+          "favorite_colors": ["blue", "green"],
+          "location": [
+            "id": 12,
+            "name": "Brooklyn",
+            "neighborhoods": [
+              ["id": 2, "name": "Williamsburg"],
+              ["id": 3, "name": "Bed-Stuy"],
+            ]
+          ]
+        ]
+        ).replacingOccurrences(of: "&", with: "&\n")
+    )
+  }
+
+  func testEncoding_Emtpy() {
+    assertSnapshot(
+      matching: urlFormEncode(
+        value: [
+          "id": 42,
+          "name": "Blob McBlob",
+          "empty_array": [],
+          "empty_object": [:],
+          ]
+        ).replacingOccurrences(of: "&", with: "&\n")
+    )
+  }
+
+  func testEncoding_RootArray_SimpleObjects() {
+    assertSnapshot(
+      matching: urlFormEncode(
+        values: ["Functions & Purity", "Monoids", "Applicatives"],
+        rootKey: "episodes"
+        )
+        .replacingOccurrences(of: "&", with: "&\n")
+    )
+  }
+
+  func testEncoding_DoubleArray() {
+    assertSnapshot(
+      matching: urlFormEncode(
+        values: [
+          ["Functions", "Purity"],
+          ["Semigroups", "Monoids"],
+          ["Applicatives", "Monads"]
+        ],
+        rootKey: "episodes"
+        )
+        .replacingOccurrences(of: "&", with: "&\n")
+    )
+  }
+
+  func testEncodingCodable() {
+    let episode = EpisodeModel(
+      id: 100, title: "Introduction to Functions",
+      blurb: "Everything you wanted to know about functions.",
+      categories: ["Functions", "Composition", "Curry"]
+    )
+
+    assertSnapshot(
+      matching: urlFormEncode(value: episode).replacingOccurrences(of: "&", with: "&\n")
+    )
+  }
+}
+
+private struct EpisodeModel: Codable {
+  let id: Int
+  let title: String
+  let blurb: String
+  let categories: [String]
+}

--- a/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncodingCodable.1.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncodingCodable.1.txt
@@ -1,0 +1,6 @@
+blurb=Everything%20you%20wanted%20to%20know%20about%20functions.&
+title=Introduction%20to%20Functions&
+id=100&
+categories[0]=Functions&
+categories[1]=Composition&
+categories[2]=Curry

--- a/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_DeepObject.1.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_DeepObject.1.txt
@@ -1,0 +1,11 @@
+name=Blob%20McBlob&
+location[id]=12&
+location[name]=Brooklyn&
+location[neighborhoods][0][id]=2&
+location[neighborhoods][0][name]=Williamsburg&
+location[neighborhoods][1][id]=3&
+location[neighborhoods][1][name]=Bed-Stuy&
+id=42&
+favorite_colors[0]=blue&
+favorite_colors[1]=green&
+bio=!*'();:@%26%3D+$,/%3F%%23[]%20^

--- a/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_DoubleArray.1.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_DoubleArray.1.txt
@@ -1,0 +1,6 @@
+episodes[0][0]=Functions&
+episodes[0][1]=Purity&
+episodes[1][0]=Semigroups&
+episodes[1][1]=Monoids&
+episodes[2][0]=Applicatives&
+episodes[2][1]=Monads

--- a/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_Emtpy.1.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_Emtpy.1.txt
@@ -1,0 +1,3 @@
+name=Blob%20McBlob&
+&
+id=42&

--- a/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_RootArray_SimpleObjects.1.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/UrlFormEncodingTests/testEncoding_RootArray_SimpleObjects.1.txt
@@ -1,0 +1,3 @@
+episodes[0]=Functions%20%26%20Purity&
+episodes[1]=Monoids&
+episodes[2]=Applicatives


### PR DESCRIPTION
Pulled out some functions I wrote in a different branch for doing URL form encoding. I don't really know if this is the right way to do form encoding, but it works for our basic needs for now (which is for submitting data to the Stripe API).

One bummer is that we cannot do the reverse since the encoded data is all stringly typed. I wonder if we could do something like the router to have a parser-printer for form data...