### PR TITLE
Improved data handling

### DIFF
--- a/Sources/ApplicativeRouter/SomePartialIsos.swift
+++ b/Sources/ApplicativeRouter/SomePartialIsos.swift
@@ -88,7 +88,7 @@ extension PartialIso where A == String, B == Data {
   public static var data: PartialIso<String, Data> {
     return .init(
       apply: { Data($0.utf8) },
-      unapply: { String(data: $0, encoding: .utf8) }
+      unapply: { String(decoding: $0, as: UTF8.self) }
     )
   }
 }

--- a/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
+++ b/Sources/ApplicativeRouterHttpPipelineSupport/ApplicativeRouterHttpPipelineSupport.swift
@@ -11,10 +11,10 @@ import Prelude
 ///   - notFound: Middleware to run if a route is not recognized.
 public func route<A, Route>(
   router: Router<Route>,
-  notFound: @escaping Middleware<StatusLineOpen, ResponseEnded, A, Data?> = notFound(respond(text: "don't know that url"))
+  notFound: @escaping Middleware<StatusLineOpen, ResponseEnded, A, Data> = notFound(respond(text: "Not Found"))
   )
-  -> (@escaping Middleware<StatusLineOpen, ResponseEnded, Route, Data?>)
-  -> Middleware<StatusLineOpen, ResponseEnded, A, Data?> {
+  -> (@escaping Middleware<StatusLineOpen, ResponseEnded, Route, Data>)
+  -> Middleware<StatusLineOpen, ResponseEnded, A, Data> {
 
     return { middleware in
       return { conn in

--- a/Sources/HttpPipeline/Response.swift
+++ b/Sources/HttpPipeline/Response.swift
@@ -3,5 +3,5 @@ import Foundation
 public struct Response {
   public private(set) var status: Status
   public private(set) var headers: [ResponseHeader]
-  public private(set) var body: Data?
+  public private(set) var body: Data
 }

--- a/Sources/HttpPipeline/SignedCookies.swift
+++ b/Sources/HttpPipeline/SignedCookies.swift
@@ -95,7 +95,7 @@ extension ResponseHeader {
   public static func verifiedString(signedCookieValue: String, secret: String)
     -> String? {
       return verifiedData(signedCookieValue: signedCookieValue, secret: secret)
-        .flatMap { String(data: $0, encoding: .utf8) }
+        .map { String(decoding: $0, as: UTF8.self) }
   }
 
   /// Helper function that calls `verifiedData` and then tries to decode the data into an `A`.

--- a/Sources/HttpPipelineHtmlSupport/Support.swift
+++ b/Sources/HttpPipelineHtmlSupport/Support.swift
@@ -3,10 +3,10 @@ import Html
 import HttpPipeline
 import Prelude
 
-public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded, A, Data?> {
+public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded, A, Data> {
   
   return
-    map { view.rendered(with: $0).data(using: .utf8) }
+    map { Data(view.rendered(with: $0).utf8) }
       >>> writeHeader(.contentType(.html))
       >-> closeHeaders
       >-> end

--- a/Sources/HttpPipelineTestSupport/HttpPipelineTestSupport.swift
+++ b/Sources/HttpPipelineTestSupport/HttpPipelineTestSupport.swift
@@ -27,7 +27,7 @@ extension Response: Snapshot {
 
     if contentMediaType?.application?.isOther == .some(true) || contentMediaType?.isText == .some(true) {
       // todo: use proper encoding when available
-      return top + "\n\n\(self.body.flatMap { String(data: $0, encoding: .utf8) } ?? "")\n"
+      return top + "\n\n\(String(decoding: self.body, as: UTF8.self))\n"
     }
     return top
   }
@@ -65,7 +65,7 @@ extension URLRequest: Snapshot {
       + headers
     let top = lines.joined(separator: "\n")
 
-    let body = self.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+    let body = self.httpBody.map { String(decoding: $0, as: UTF8.self) }
       ?? "(Data, \(self.httpBody?.count ?? 0) bytes)"
 
     return """

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/ApplicativeRouterHttpPipelineSupportTests.swift
@@ -12,7 +12,7 @@ class ApplicativeRouterHttpPipelineSupportTests: XCTestCase {
       Route.iso.home <¢> get <% end
         <|> Route.iso.episode <¢> get %> lit("episode") %> .string <% end
 
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       route(router: router)
         <| writeStatus(.ok)
         >-> { $0 |> respond(text: "Recognized route: \($0.data)") }
@@ -36,7 +36,7 @@ class ApplicativeRouterHttpPipelineSupportTests: XCTestCase {
   func testRoute_UnrecognizedWithCustomNotFound() {
     let router = Route.iso.home <¢> get <% end
 
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       route(router: router, notFound: notFound(respond(text: "Unrecognized route!")))
         <| writeStatus(.ok)
         >-> { $0 |> respond(text: "Recognized route: \($0.data)") }

--- a/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.3.unrecognized.Conn.txt
+++ b/Tests/ApplicativeRouterHttpPipelineSupportTests/__Snapshots__/ApplicativeRouterHttpPipelineSupportTests/testRoute.3.unrecognized.Conn.txt
@@ -8,7 +8,7 @@
 
 ▿ Response
   Status 404 NOT FOUND
-  Content-Length: 19
+  Content-Length: 9
   Content-Type: text/plain
 
-  don't know that url
+  Not Found

--- a/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
+++ b/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
@@ -16,8 +16,8 @@ class HttpPipelineHtmlSupportTests: XCTestCase {
     XCTAssertEqual(200, response.response.status.rawValue)
     XCTAssertEqual(
       "Content-Type: text/html; charset=utf8",
-      response.response.headers.map { $0.description }.joined(separator: "")
+      response.response.headers.map(get(\.description)).joined(separator: "")
     )
-    XCTAssertEqual("<p>Hello world!</p>", String(data: response.response.body!, encoding: .utf8))
+    XCTAssertEqual("<p>Hello world!</p>", String(decoding: response.response.body, as: UTF8.self))
   }
 }

--- a/Tests/HttpPipelineTests/HttpPipelineTests.swift
+++ b/Tests/HttpPipelineTests/HttpPipelineTests.swift
@@ -9,7 +9,7 @@ private let conn = connection(from: URLRequest(url: URL(string: "/")!))
 
 class HttpPipelineTests: XCTestCase {
   func testPipeline() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       writeStatus(.ok)
         >-> respond(text: "Hello, world")
 
@@ -17,7 +17,7 @@ class HttpPipelineTests: XCTestCase {
   }
 
   func testHtmlResponse() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       writeStatus(.ok)
         >-> respond(html: "<p>Hello, world</p>")
 
@@ -25,20 +25,20 @@ class HttpPipelineTests: XCTestCase {
   }
 
   func testRedirect() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> = redirect(to: "/sign-in")
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> = redirect(to: "/sign-in")
 
     assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testRedirect_AdditionalHeaders() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       redirect(to: "/sign-in", headersMiddleware: writeHeader("Pass-through", "hello!"))
 
     assertSnapshot(matching: middleware(conn).perform())
   }
 
   func testWriteHeaders() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       writeStatus(.ok)
         >-> writeHeader("Z", "Header should be last")
         >-> writeHeader("Hello", "World")
@@ -50,7 +50,7 @@ class HttpPipelineTests: XCTestCase {
   }
 
   func testCookies() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       writeStatus(.ok)
         >-> writeHeader(.setCookie(key: "user_id", value: "123456", options: []))
         >-> writeHeader(.setCookie(key: "lang", value: "es", options: []))
@@ -61,7 +61,7 @@ class HttpPipelineTests: XCTestCase {
   }
 
   func testCookieOptions() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       writeStatus(.ok)
         >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.domain("www.pointfree.co")]))
         >-> writeHeader(.setCookie(key: "foo", value: "bar", options: [.expires(1234567890)]))

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -9,7 +9,7 @@ private let conn = connection(from: URLRequest(url: URL(string: "/")!))
 
 class SharedMiddlewareTransformersTests: XCTestCase {
   func testBasicAuth_Unauthorized() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World")
         <| writeStatus(.ok)
         >-> respond(html: "<p>Hello, world</p>")
@@ -18,7 +18,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   }
 
   func testBasicAuth_Unauthorized_ProtectedPredicate() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World", protect: const(false))
         <| writeStatus(.ok)
         >-> respond(html: "<p>Hello, world</p>")
@@ -27,7 +27,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   }
 
   func testBasicAuth_Unauthorized_Realm() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World", realm: "Point-Free")
         <| writeStatus(.ok)
         >-> respond(html: "<p>Hello, world</p>")
@@ -36,7 +36,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   }
 
   func testBasicAuth_Unauthorized_CustomFailure() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(
         user: "Hello",
         password: "World",
@@ -49,7 +49,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   }
 
   func testBasicAuth_Authorized() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World")
         <| writeStatus(.ok)
         >-> respond(html: "<p>Hello, world</p>")
@@ -63,13 +63,13 @@ class SharedMiddlewareTransformersTests: XCTestCase {
   }
 
   func testContentLengthMiddlewareTransformer() {
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       contentLength
         <| writeStatus(.ok)
         >-> writeHeader(.contentType(.html))
         >-> closeHeaders
         >-> map(const(Data())) >>> pure
-        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> send(Data("<p>Hello, world</p>".utf8))
         >-> end
 
     assertSnapshot(matching: middleware(conn).perform())
@@ -83,13 +83,13 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       "0.0.0.0",
     ]
 
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       redirectUnrelatedHosts(allowedHosts: allowedHosts, canonicalHost: "www.pointfree.co")
         <| writeStatus(.ok)
         >-> writeHeader(.contentType(.html))
         >-> closeHeaders
         >-> map(const(Data())) >>> pure
-        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> send(Data("<p>Hello, world</p>".utf8))
         >-> end
 
     assertSnapshot(
@@ -113,13 +113,13 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       "0.0.0.0",
       ]
 
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       requireHerokuHttps(allowedInsecureHosts: allowedInsecureHosts)
         <| writeStatus(.ok)
         >-> writeHeader(.contentType(.html))
         >-> closeHeaders
         >-> map(const(Data())) >>> pure
-        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> send(Data("<p>Hello, world</p>".utf8))
         >-> end
 
     func securedConnection(from request: URLRequest) -> Conn<StatusLineOpen, Prelude.Unit> {
@@ -147,13 +147,13 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       "0.0.0.0",
       ]
 
-    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data?> =
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       requireHttps(allowedInsecureHosts: allowedInsecureHosts)
         <| writeStatus(.ok)
         >-> writeHeader(.contentType(.html))
         >-> closeHeaders
         >-> map(const(Data())) >>> pure
-        >-> send("<p>Hello, world</p>".data(using: .utf8))
+        >-> send(Data("<p>Hello, world</p>".utf8))
         >-> end
 
     assertSnapshot(


### PR DESCRIPTION
  - Prefer typed guarantees of `String(decoding:as:)` over `String(data:encoding:)`
  - Prefer typed guarantees of `Data(string.utf8)` over `string.data(encoding: .utf8)`.
  - Rename `Conn<Step, Data>` to `Conn<Step, A>`
  - Don't use `Data?` in pipeline: respond with `Conn<ResponseEnded, Data>`, not `Conn<ResponseEnded, Data?>`

I'm not sure if we were depending on a semantic difference with `Data?`, but it seems unnecessary.