### PR TITLE
Fix another crash around URLComponents/URLQueryItem

### DIFF
--- a/Sources/ApplicativeRouter/SyntaxRouter.swift
+++ b/Sources/ApplicativeRouter/SyntaxRouter.swift
@@ -137,12 +137,11 @@ extension Router {
 private func requestData(from request: URLRequest) -> RequestData {
   let method = request.httpMethod.flatMap(Method.init(string:)) ?? .get
 
-  var query = [String: String]()
-
   guard let url = request.url else {
     return .init(method: method, path: [], query: [:], body: request.httpBody)
   }
 
+  var query: [String: String] = [:]
   url.query?.split(separator: "&").forEach {
     let pair = $0.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
     query[pair[0].removingPercentEncoding ?? ""] = pair[1].removingPercentEncoding ?? ""

--- a/Sources/ApplicativeRouter/SyntaxRouter.swift
+++ b/Sources/ApplicativeRouter/SyntaxRouter.swift
@@ -144,7 +144,7 @@ private func requestData(from request: URLRequest) -> RequestData {
   var query: [String: String] = [:]
   url.query?.split(separator: "&").forEach {
     let pair = $0.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-    query[pair[0].removingPercentEncoding ?? ""] = pair[1].removingPercentEncoding ?? ""
+    query[String(pair[0]).removingPercentEncoding ?? ""] = String(pair[1]).removingPercentEncoding ?? ""
   }
 
   let path = url.path.components(separatedBy: "/")


### PR DESCRIPTION
This one took awhile to track down! It appears that Linux Foundation has some issues with URLComponents and URLs that contain the same query key twice. Let's avoid URLComponents for now, and have a coupla action items:

1. Change it so our GitHub response code string is optional (to avoid the double query, which is kinda undefined behavior).
2. Get a failing test case over to Apple.