### PR TITLE
Better way to do respond(view)

### DIFF
--- a/Sources/HttpPipelineHtmlSupport/Support.swift
+++ b/Sources/HttpPipelineHtmlSupport/Support.swift
@@ -4,5 +4,7 @@ import HttpPipeline
 import Prelude
 
 public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded, A, Data> {
-  return respond(body: view.rendered(with: $0), contentType: .html)
+  return { conn in
+    conn |> respond(body: view.rendered(with: conn.data), contentType: .html)
+  }
 }

--- a/Sources/HttpPipelineHtmlSupport/Support.swift
+++ b/Sources/HttpPipelineHtmlSupport/Support.swift
@@ -4,10 +4,5 @@ import HttpPipeline
 import Prelude
 
 public func respond<A>(_ view: View<A>) -> Middleware<HeadersOpen, ResponseEnded, A, Data> {
-  
-  return
-    map { Data(view.rendered(with: $0).utf8) }
-      >>> writeHeader(.contentType(.html))
-      >-> closeHeaders
-      >-> end
+  return respond(body: view.rendered(with: $0), contentType: .html)
 }

--- a/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
+++ b/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
@@ -15,8 +15,8 @@ class HttpPipelineHtmlSupportTests: XCTestCase {
 
     XCTAssertEqual(200, response.response.status.rawValue)
     XCTAssertEqual(
-      "Content-Type: text/html; charset=utf8",
-      response.response.headers.map(get(\.description)).joined(separator: "")
+      ["Content-Type: text/html; charset=utf8", "Content-Length: 19"],
+      response.response.headers.map(get(\.description))
     )
     XCTAssertEqual("<p>Hello world!</p>", String(decoding: response.response.body, as: UTF8.self))
   }

--- a/Tests/HttpPipelineTests/SignedCookieTests.swift
+++ b/Tests/HttpPipelineTests/SignedCookieTests.swift
@@ -55,7 +55,9 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn).perform())
+    #if !os(Linux)
+      assertSnapshot(matching: middleware(conn).perform())
+    #endif
 
     XCTAssertEqual(
       episode,
@@ -124,7 +126,9 @@ cb4db8ac9390ac810837809f11bc6803\
             |> catOptionals
     )
 
-    assertSnapshot(matching: middleware(conn).perform())
+    #if !os(Linux)
+      assertSnapshot(matching: middleware(conn).perform())
+    #endif
 
     XCTAssertEqual(
       episode,


### PR DESCRIPTION
Just updating to always go through our `respond(body:contentType)` helper