### PR TITLE
Add URL Form Decoder for Decodable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.1.0"
+      xcode: "9.2.0"
 
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ imports = \
 	@testable import HtmlPrettyPrintTests; \
 	@testable import HttpPipelineTests; \
 	@testable import HttpPipelineHtmlSupportTests; \
-	@testable import UrlFormDecoderTests; \
-	@testable import UrlFormEncodingTests; 
+	@testable import UrlFormEncodingTests;
 
 xcodeproj:
 	swift package generate-xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ imports = \
 	@testable import HtmlPrettyPrintTests; \
 	@testable import HttpPipelineTests; \
 	@testable import HttpPipelineHtmlSupportTests; \
-	@testable import UrlFormEncodingTests;
+	@testable import UrlFormDecoderTests; \
+	@testable import UrlFormEncodingTests; 
 
 xcodeproj:
 	swift package generate-xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-ios: xcodeproj
 	set -o pipefail && \
 	xcodebuild test \
 		-scheme Web-Package \
-		-destination platform="iOS Simulator,name=iPhone 8,OS=11.1" \
+		-destination platform="iOS Simulator,name=iPhone 8,OS=11.2" \
 		| xcpretty
 
 test-swift:

--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,7 @@ let package = Package(
 
     .target(name: "MediaType", dependencies: []),
 
-    .target(name: "UrlFormEncoding", dependencies: ["Prelude"]),
+    .target(name: "UrlFormEncoding", dependencies: ["Prelude", "Optics"]),
     .testTarget(name: "UrlFormEncodingTests", dependencies: ["UrlFormEncoding", "SnapshotTesting"]),
   ]
 )

--- a/Sources/UrlFormEncoding/UrlFormDecoder.swift
+++ b/Sources/UrlFormEncoding/UrlFormDecoder.swift
@@ -618,7 +618,7 @@ private func pairs(_ query: String) -> [(String, String)] {
     .split(separator: "&")
     .map { (pairString: Substring) -> (name: String, value: String) in
       let pairArray = pairString.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-        .flatMap { $0.removingPercentEncoding }
+        .flatMap { String($0).removingPercentEncoding }
       return (pairArray[0], pairArray.count == 2 ? pairArray[1] : "")
     }
     .sorted { $0.name < $1.name }

--- a/Sources/UrlFormEncoding/UrlFormDecoder.swift
+++ b/Sources/UrlFormEncoding/UrlFormDecoder.swift
@@ -1,0 +1,629 @@
+import Foundation
+import Optics
+import Prelude
+
+public final class UrlFormDecoder: Decoder {
+  private(set) var containers: [Any] = []
+  private var container: Any {
+    return containers.last!
+  }
+  public private(set) var codingPath: [CodingKey] = []
+  public var dataDecodingStrategy: DataDecodingStrategy = .deferredToData
+  public var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+  public var parsingStrategy: ParsingStrategy = .accumulatePairs
+  public let userInfo: [CodingUserInfoKey: Any] = [:]
+
+  public init() {
+  }
+
+  public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    let container = self.parsingStrategy.strategy(String(decoding: data, as: UTF8.self))
+    self.containers.append(container)
+    defer { self.containers.removeLast() }
+    return try T(from: self)
+  }
+
+  private func unbox(_ value: Any, as type: Data.Type) throws -> Data {
+    guard let string = singleton(value) else {
+      throw Error.decodingError("Expected string data, got \(value)", self.codingPath)
+    }
+
+    switch self.dataDecodingStrategy {
+    case .deferredToData:
+      return try Data(from: self)
+    case .base64:
+      guard let data = Data(base64Encoded: string) else {
+        throw Error.decodingError("Expected base64-encoded data, got \(string)", self.codingPath)
+      }
+      return data
+    case let .custom(strategy):
+      guard let data = strategy(string) else {
+        throw Error.decodingError("Failed strategy when decoding data from \(string)", self.codingPath)
+      }
+      return data
+    }
+  }
+
+  private func unbox(_ value: Any, as type: Date.Type) throws -> Date {
+    guard let string = singleton(value) else {
+      throw Error.decodingError("Expected string date, got \(value)", self.codingPath)
+    }
+
+    switch self.dateDecodingStrategy {
+    case .deferredToDate:
+      return try Date(from: self)
+    case .secondsSince1970:
+      guard let date = Double(string).map(Date.init(timeIntervalSince1970:)) else {
+        throw Error.decodingError("Expected seconds, got \(string)", self.codingPath)
+      }
+      return date
+    case .millisecondsSince1970:
+      guard let date = Double(string).map({ Date(timeIntervalSince1970: $0 / 1000) }) else {
+        throw Error.decodingError("Expected milliseconds, got \(string)", self.codingPath)
+      }
+      return date
+    case .iso8601:
+      let someDate = iso8601DateFormatter.date(from: string)
+        ?? iso8601DateFormatterWithoutMilliseconds.date(from: string)
+      guard let date = someDate else {
+        throw Error.decodingError("Expected ISO 8601 date string, got \(string)", self.codingPath)
+      }
+      return date
+    case let .formatted(formatter):
+      guard let date = formatter.date(from: string) else {
+        throw Error.decodingError("Expected \(formatter.dateFormat), got \(string)", self.codingPath)
+      }
+      return date
+    case let .custom(strategy):
+      guard let data = strategy(string) else {
+        throw Error.decodingError("Failed strategy when decoding data from \(string)", self.codingPath)
+      }
+      return data
+    }
+  }
+
+  private func unbox<T: Decodable>(_ value: Any, as type: T.Type) throws -> T {
+    if type == Data.self {
+      return try self.unbox(value, as: Data.self) as! T
+    } else if type == Date.self {
+      return try self.unbox(value, as: Date.self) as! T
+    } else {
+      return try T(from: self)
+    }
+  }
+
+  public func container<Key>(keyedBy type: Key.Type) throws
+    -> KeyedDecodingContainer<Key>
+    where Key: CodingKey {
+
+      guard let container = self.container as? [String: Any] else {
+        throw Error.decodingError("Expected keyed container, got \(self.container)", self.codingPath)
+      }
+      return .init(KeyedContainer(decoder: self, container: container))
+  }
+
+  public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+    guard let container = self.container as? [Any] else {
+      throw Error.decodingError("Expected unkeyed container, got \(self.container)", self.codingPath)
+    }
+    return UnkeyedContainer(decoder: self, container: container, codingPath: self.codingPath)
+  }
+
+  public func singleValueContainer() throws -> SingleValueDecodingContainer {
+    return SingleValueContainer(decoder: self, container: self.container)
+  }
+
+  public enum Error: Swift.Error {
+    case decodingError(String, [CodingKey])
+  }
+
+  struct KeyedContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+    private(set) var decoder: UrlFormDecoder
+    let container: [String: Any]
+
+    var codingPath: [CodingKey] {
+      return self.decoder.codingPath
+    }
+    var allKeys: [Key] {
+      return self.container.keys.flatMap(Key.init(stringValue:))
+    }
+
+    private func checked<T>(_ key: Key, _ block: (String) throws -> T) throws -> T {
+      guard let value = self.container[key.stringValue].flatMap(singleton) else {
+        throw Error.decodingError("Expected \(T.self) at \(key), got nil", self.codingPath)
+      }
+      return try block(value)
+    }
+
+    private func unwrap<T>(_ key: Key, _ block: (String) -> T?) throws -> T {
+      guard let value = try self.checked(key, block) else {
+        throw Error.decodingError("Expected \(T.self) at \(key), got nil", self.codingPath)
+      }
+      return value
+    }
+
+    func contains(_ key: Key) -> Bool {
+      return self.container[key.stringValue] != nil
+    }
+
+    func decodeNil(forKey key: Key) throws -> Bool {
+      return try self.checked(key, ^\.isEmpty)
+    }
+
+    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+      return try self.unwrap(key, Bool.init)
+    }
+
+    func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+      return try self.unwrap(key, Int.init)
+    }
+
+    func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+      return try self.unwrap(key, Int8.init)
+    }
+
+    func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+      return try self.unwrap(key, Int16.init)
+    }
+
+    func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+      return try self.unwrap(key, Int32.init)
+    }
+
+    func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+      return try self.unwrap(key, Int64.init)
+    }
+
+    func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+      return try self.unwrap(key, UInt.init)
+    }
+
+    func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+      return try self.unwrap(key, UInt8.init)
+    }
+
+    func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+      return try self.unwrap(key, UInt16.init)
+    }
+
+    func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+      return try self.unwrap(key, UInt32.init)
+    }
+
+    func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+      return try self.unwrap(key, UInt64.init)
+    }
+
+    func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+      return try self.unwrap(key, Float.init)
+    }
+
+    func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+      return try self.unwrap(key, Double.init)
+    }
+
+    func decode(_ type: String.Type, forKey key: Key) throws -> String {
+      return try self.unwrap(key, id)
+    }
+
+    func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
+      self.decoder.codingPath.append(key)
+      defer { self.decoder.codingPath.removeLast() }
+      guard let container = self.container[key.stringValue] else {
+        throw Error.decodingError("Expected \(T.self) at \(key), got nil", self.codingPath)
+      }
+      self.decoder.containers.append(container)
+      defer { self.decoder.containers.removeLast() }
+      return try self.decoder.unbox(container, as: T.self)
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws
+      -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        print(1)
+        guard let container = self.container[key.stringValue] as? [String: Any] else {
+          throw Error.decodingError("Expected value at \(key), got nil", self.codingPath)
+        }
+        self.decoder.containers.append(container)
+        defer { self.decoder.containers.removeLast() }
+        return .init(KeyedContainer<NestedKey>(decoder: self.decoder, container: container))
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+      self.decoder.codingPath.append(key)
+      defer { self.decoder.codingPath.removeLast() }
+      print(2)
+      guard let container = self.container[key.stringValue] as? [Any] else {
+        throw Error.decodingError("Expected value at \(key), got nil", self.codingPath)
+      }
+      self.decoder.containers.append(container)
+      defer { self.decoder.containers.removeLast() }
+      return UnkeyedContainer(decoder: self.decoder, container: container, codingPath: self.codingPath)
+    }
+
+    func superDecoder() throws -> Decoder {
+      fatalError()
+    }
+
+    func superDecoder(forKey key: Key) throws -> Decoder {
+      self.decoder.codingPath.append(key)
+      defer { self.decoder.codingPath.removeLast() }
+      print(3)
+      guard let container = self.container[key.stringValue] else {
+        throw Error.decodingError("Expected value at \(key), got nil", self.codingPath)
+      }
+      let decoder = UrlFormDecoder()
+      decoder.containers = [container]
+      decoder.codingPath = self.codingPath
+      return decoder
+    }
+  }
+
+  struct UnkeyedContainer: UnkeyedDecodingContainer {
+    struct Key {
+      let index: Int
+    }
+
+    let decoder: UrlFormDecoder
+    let container: [Any]
+
+    private(set) var codingPath: [CodingKey]
+    var count: Int? {
+      return self.container.count
+    }
+    var isAtEnd: Bool {
+      return self.currentIndex >= self.container.count
+    }
+    private(set) var currentIndex: Int = 0
+
+    init(decoder: UrlFormDecoder, container: [Any], codingPath: [CodingKey]) {
+      self.decoder = decoder
+      self.container = container
+      self.codingPath = codingPath
+    }
+
+    mutating private func checked<T>(_ block: (String) throws -> T) throws -> T {
+      guard !self.isAtEnd else { throw Error.decodingError("Unkeyed container is at end", self.codingPath) }
+      self.codingPath.append(Key(index: self.currentIndex))
+      defer { self.codingPath.removeLast() }
+      guard let container = singleton(self.container[self.currentIndex]) else {
+        throw Error.decodingError("Expected \(T.self) at \(self.currentIndex), got nil", self.codingPath)
+      }
+      let value = try block(container)
+      self.currentIndex += 1
+      return value
+    }
+
+    mutating private func unwrap<T>(_ block: (String) -> T?) throws -> T {
+      guard let value = try self.checked(block) else {
+        throw Error.decodingError("Expected \(T.self) at \(self.currentIndex), got nil", self.codingPath)
+      }
+      return value
+    }
+
+    mutating func decodeNil() throws -> Bool {
+      return try self.unwrap(^\.isEmpty)
+    }
+
+    mutating func decode(_ type: Bool.Type) throws -> Bool {
+      return try self.unwrap(Bool.init)
+    }
+
+    mutating func decode(_ type: Int.Type) throws -> Int {
+      return try self.unwrap(Int.init)
+    }
+
+    mutating func decode(_ type: Int8.Type) throws -> Int8 {
+      return try self.unwrap(Int8.init)
+    }
+
+    mutating func decode(_ type: Int16.Type) throws -> Int16 {
+      return try self.unwrap(Int16.init)
+    }
+
+    mutating func decode(_ type: Int32.Type) throws -> Int32 {
+      return try self.unwrap(Int32.init)
+    }
+
+    mutating func decode(_ type: Int64.Type) throws -> Int64 {
+      return try self.unwrap(Int64.init)
+    }
+
+    mutating func decode(_ type: UInt.Type) throws -> UInt {
+      return try self.unwrap(UInt.init)
+    }
+
+    mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+      return try self.unwrap(UInt8.init)
+    }
+
+    mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+      return try self.unwrap(UInt16.init)
+    }
+
+    mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+      return try self.unwrap(UInt32.init)
+    }
+
+    mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+      return try self.unwrap(UInt64.init)
+    }
+
+    mutating func decode(_ type: Float.Type) throws -> Float {
+      return try self.unwrap(Float.init)
+    }
+
+    mutating func decode(_ type: Double.Type) throws -> Double {
+      return try self.unwrap(Double.init)
+    }
+
+    mutating func decode(_ type: String.Type) throws -> String {
+      return try self.unwrap(id)
+    }
+
+    mutating func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+      guard !self.isAtEnd else { throw Error.decodingError("Unkeyed container is at end", self.codingPath) }
+      self.codingPath.append(Key(index: self.currentIndex))
+      defer { self.codingPath.removeLast() }
+      let container = self.container[self.currentIndex]
+      self.currentIndex += 1
+      self.decoder.containers.append(container)
+      defer { self.decoder.containers.removeLast() }
+      return try self.decoder.unbox(container, as: T.self)
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws
+      -> KeyedDecodingContainer<NestedKey>
+      where NestedKey: CodingKey {
+
+        guard !self.isAtEnd else { throw Error.decodingError("Unkeyed container is at end", self.codingPath) }
+        defer { self.codingPath.removeLast() }
+        guard let container = self.container[self.currentIndex] as? [String: Any] else {
+          throw Error.decodingError("Expected value at \(self.currentIndex), got nil", self.codingPath)
+        }
+        self.currentIndex += 1
+        self.decoder.containers.append(container)
+        defer { self.decoder.containers.removeLast() }
+        return .init(KeyedContainer(decoder: self.decoder, container: container))
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+      guard !self.isAtEnd else { throw Error.decodingError("Unkeyed container is at end", self.codingPath) }
+      defer { self.codingPath.removeLast() }
+      guard let container = self.container[self.currentIndex] as? [Any] else {
+        throw Error.decodingError("Expected value at \(self.currentIndex), got nil", self.codingPath)
+      }
+      self.currentIndex += 1
+      self.decoder.containers.append(container)
+      defer { self.decoder.containers.removeLast() }
+      return UnkeyedContainer(decoder: self.decoder, container: container, codingPath: self.codingPath)
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+      guard !self.isAtEnd else { throw Error.decodingError("Unkeyed container is at end", self.codingPath) }
+      defer { self.codingPath.removeLast() }
+      let container = self.container[self.currentIndex]
+      self.currentIndex += 1
+      let decoder = UrlFormDecoder()
+      decoder.containers = [container]
+      decoder.codingPath = self.codingPath
+      return decoder
+    }
+  }
+
+  struct SingleValueContainer: SingleValueDecodingContainer {
+    let decoder: UrlFormDecoder
+    let container: Any
+
+    let codingPath: [CodingKey] = []
+
+    private func unwrap<T>(_ block: (String) -> T?, _ line: UInt = #line) throws -> T {
+      guard
+        let container = self.container as? String,
+        let value = block(container)
+        else { throw Error.decodingError("Expected \(T.self), got nil", self.codingPath) }
+
+      return value
+    }
+
+    func decodeNil() -> Bool {
+      return (self.container as? String)?.isEmpty ?? false
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+      return try self.unwrap(Bool.init)
+    }
+
+    func decode(_ type: Int.Type) throws -> Int {
+      return try self.unwrap(Int.init)
+    }
+
+    func decode(_ type: Int8.Type) throws -> Int8 {
+      return try self.unwrap(Int8.init)
+    }
+
+    func decode(_ type: Int16.Type) throws -> Int16 {
+      return try self.unwrap(Int16.init)
+    }
+
+    func decode(_ type: Int32.Type) throws -> Int32 {
+      return try self.unwrap(Int32.init)
+    }
+
+    func decode(_ type: Int64.Type) throws -> Int64 {
+      return try self.unwrap(Int64.init)
+    }
+
+    func decode(_ type: UInt.Type) throws -> UInt {
+      return try self.unwrap(UInt.init)
+    }
+
+    func decode(_ type: UInt8.Type) throws -> UInt8 {
+      return try self.unwrap(UInt8.init)
+    }
+
+    func decode(_ type: UInt16.Type) throws -> UInt16 {
+      return try self.unwrap(UInt16.init)
+    }
+
+    func decode(_ type: UInt32.Type) throws -> UInt32 {
+      return try self.unwrap(UInt32.init)
+    }
+
+    func decode(_ type: UInt64.Type) throws -> UInt64 {
+      return try self.unwrap(UInt64.init)
+    }
+
+    func decode(_ type: Float.Type) throws -> Float {
+      return try self.unwrap(Float.init)
+    }
+
+    func decode(_ type: Double.Type) throws -> Double {
+      return try self.unwrap(Double.init)
+    }
+
+    func decode(_ type: String.Type) throws -> String {
+      return try self.unwrap(id)
+    }
+
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+      self.decoder.containers.append(self.container)
+      defer { self.decoder.containers.removeLast() }
+      return try self.decoder.unbox(self.container, as: T.self)
+    }
+  }
+
+  public enum DataDecodingStrategy {
+    case deferredToData
+    case base64
+    case custom((String) -> Data?)
+  }
+
+  public enum DateDecodingStrategy {
+    case deferredToDate
+    case secondsSince1970
+    case millisecondsSince1970
+    case iso8601
+    case formatted(DateFormatter)
+    case custom((String) -> Date?)
+  }
+
+  public struct ParsingStrategy {
+    let strategy: (String) -> [String: Any]
+
+    public static let accumulatePairs = ParsingStrategy { query in
+      var params: [String: Any] = [:]
+      for (name, value) in pairs(query) {
+        var values = params[name] as? [Any] ?? []
+        values.append(value)
+        params[name] = values
+      }
+      return params
+    }
+
+    public static let brackets = ParsingStrategy.custom(parse(isArray: ^\.isEmpty))
+
+    public static let bracketsWithIndices = ParsingStrategy.custom(parse(isArray: { Int($0) != nil }))
+
+    public static let custom = ParsingStrategy.init
+  }
+}
+
+extension UrlFormDecoder.UnkeyedContainer.Key: CodingKey {
+  public var stringValue: String {
+    return String(self.index)
+  }
+
+  public init?(stringValue: String) {
+    guard let intValue = Int(stringValue) else { return nil }
+    self.init(intValue: intValue)
+  }
+
+  public var intValue: Int? {
+    return .some(self.index)
+  }
+
+  public init?(intValue: Int) {
+    self.init(index: intValue)
+  }
+}
+
+private let iso8601: (DateFormatter) -> DateFormatter = {
+  $0.calendar = Calendar(identifier: .iso8601)
+  $0.locale = Locale(identifier: "en_US_POSIX")
+  $0.timeZone = TimeZone(abbreviation: "UTC")
+  return $0
+}
+
+private let iso8601DateFormatter = DateFormatter()
+  |> iso8601
+  |> \.dateFormat .~ "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+
+private let iso8601DateFormatterWithoutMilliseconds = DateFormatter()
+  |> iso8601
+  |> \.dateFormat .~ "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+
+private func parse(isArray: @escaping (String) -> Bool) -> (String) -> [String: Any] {
+  func parseHelp(_ params: inout [String: Any], _ path: [String], _ value: Any) {
+    let key = path[0]
+
+    if path.count == 1 {
+      params[key] = value
+    } else if path.count == 2 && isArray(path[1]) {
+      var values = params[key] as? [Any] ?? []
+      values.append(value)
+      params[key] = values
+    } else if isArray(path[1]) {
+      var (values, nested) = (params[key] as? [Any] ?? [], [:] as [String: Any])
+      parseHelp(&nested, Array(path[2...]), value)
+      values.append(nested)
+      params[key] = values
+    } else {
+      var values = params[key] as? [String: Any] ?? [:]
+      parseHelp(&values, Array(path[1...]), value)
+      params[key] = values
+    }
+  }
+
+  return { query in
+    var params: [String: Any] = [:]
+
+    for (name, value) in pairs(query) {
+      let result = name.reduce(into: (path: [] as [String], current: "")) { result, char in
+        switch char {
+        case "[":
+          if result.path.isEmpty {
+            result.path.append(result.current)
+            result.current.removeAll()
+          }
+        case "]":
+          result.path.append(result.current)
+          result.current.removeAll()
+        default:
+          result.current.append(char)
+        }
+      }
+      let path = result.current.isEmpty ? result.path : result.path + [result.current]
+      parseHelp(&params, path.isEmpty ? [""] : path, value)
+    }
+
+    return params
+  }
+}
+
+private func pairs(_ query: String) -> [(String, String)] {
+  return query
+    .split(separator: "&")
+    .map { (pairString: Substring) -> (name: String, value: String) in
+      let pairArray = pairString.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        .flatMap { $0.removingPercentEncoding }
+      return (pairArray[0], pairArray.count == 2 ? pairArray[1] : "")
+    }
+    .sorted { $0.name < $1.name }
+}
+
+private func singleton(_ value: Any) -> String? {
+  return value as? String ?? (value as? [String])?.last
+}

--- a/Sources/UrlFormEncoding/UrlFormDecoder.swift
+++ b/Sources/UrlFormEncoding/UrlFormDecoder.swift
@@ -513,7 +513,7 @@ public final class UrlFormDecoder: Decoder {
   public struct ParsingStrategy {
     let strategy: (String) -> [String: Any]
 
-    public static let accumulatePairs = ParsingStrategy { query in
+    public static let accumulatePairs = custom { query in
       var params: [String: Any] = [:]
       for (name, value) in pairs(query) {
         var values = params[name] as? [Any] ?? []
@@ -523,11 +523,11 @@ public final class UrlFormDecoder: Decoder {
       return params
     }
 
-    public static let brackets = ParsingStrategy.custom(parse(isArray: ^\.isEmpty))
+    public static let brackets = custom(parse(isArray: ^\.isEmpty))
 
-    public static let bracketsWithIndices = ParsingStrategy.custom(parse(isArray: { Int($0) != nil }))
+    public static let bracketsWithIndices = custom(parse(isArray: { Int($0) != nil }))
 
-    public static let custom = ParsingStrategy.init
+    public static let custom = `init`
   }
 }
 

--- a/Sources/UrlFormEncoding/UrlFormDecoder.swift
+++ b/Sources/UrlFormEncoding/UrlFormDecoder.swift
@@ -550,12 +550,9 @@ extension UrlFormDecoder.UnkeyedContainer.Key: CodingKey {
   }
 }
 
-private let iso8601: (DateFormatter) -> DateFormatter = {
-  $0.calendar = Calendar(identifier: .iso8601)
-  $0.locale = Locale(identifier: "en_US_POSIX")
-  $0.timeZone = TimeZone(abbreviation: "UTC")
-  return $0
-}
+private let iso8601 = ((\DateFormatter.calendar) .~ Calendar(identifier: .iso8601))
+  >>> ((\DateFormatter.locale) .~ Locale(identifier: "en_US_POSIX"))
+  >>> ((\DateFormatter.timeZone) .~ TimeZone(abbreviation: "UTC"))
 
 private let iso8601DateFormatter = DateFormatter()
   |> iso8601

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,7 +3,7 @@
 
 import XCTest
 
-@testable import ApplicativeRouterHttpPipelineSupportTests; @testable import ApplicativeRouterTests; @testable import CssTests; @testable import CssResetTests; @testable import HtmlTests; @testable import HtmlCssSupportTests; @testable import HtmlPrettyPrintTests; @testable import HttpPipelineTests; @testable import HttpPipelineHtmlSupportTests; @testable import UrlFormEncodingTests;
+@testable import ApplicativeRouterHttpPipelineSupportTests; @testable import ApplicativeRouterTests; @testable import CssTests; @testable import CssResetTests; @testable import HtmlTests; @testable import HtmlCssSupportTests; @testable import HtmlPrettyPrintTests; @testable import HttpPipelineTests; @testable import HttpPipelineHtmlSupportTests; @testable import UrlFormDecoderTests; @testable import UrlFormEncodingTests;
 extension ApplicativeRouterHttpPipelineSupportTests {
   static var allTests: [(String, (ApplicativeRouterHttpPipelineSupportTests) -> () throws -> Void)] = [
     ("testRoute", testRoute),
@@ -192,6 +192,17 @@ extension SyntaxRouterTests {
     ("testSimpleQueryParams_SomeMissing", testSimpleQueryParams_SomeMissing)
   ]
 }
+extension UrlFormDecoderTests {
+  static var allTests: [(String, (UrlFormDecoderTests) -> () throws -> Void)] = [
+    ("testDefaultStrategyAccumulatePairs", testDefaultStrategyAccumulatePairs),
+    ("testBrackets", testBrackets),
+    ("testBracketsWithIndices", testBracketsWithIndices),
+    ("testDataDecodingWithBase64", testDataDecodingWithBase64),
+    ("testDateDecodingWithSecondsSince1970", testDateDecodingWithSecondsSince1970),
+    ("testDateDecodingWithMillisecondsSince1970", testDateDecodingWithMillisecondsSince1970),
+    ("testDateDecodingWithIso8601", testDateDecodingWithIso8601)
+  ]
+}
 extension UrlFormEncoderTests {
   static var allTests: [(String, (UrlFormEncoderTests) -> () throws -> Void)] = [
     ("testEncoding_DeepObject", testEncoding_DeepObject),
@@ -233,6 +244,7 @@ XCTMain([
   testCase(SizeTests.allTests),
   testCase(SupportTests.allTests),
   testCase(SyntaxRouterTests.allTests),
+  testCase(UrlFormDecoderTests.allTests),
   testCase(UrlFormEncoderTests.allTests),
   testCase(ViewTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,7 +3,7 @@
 
 import XCTest
 
-@testable import ApplicativeRouterHttpPipelineSupportTests; @testable import ApplicativeRouterTests; @testable import CssTests; @testable import CssResetTests; @testable import HtmlTests; @testable import HtmlCssSupportTests; @testable import HtmlPrettyPrintTests; @testable import HttpPipelineTests; @testable import HttpPipelineHtmlSupportTests; @testable import UrlFormDecoderTests; @testable import UrlFormEncodingTests;
+@testable import ApplicativeRouterHttpPipelineSupportTests; @testable import ApplicativeRouterTests; @testable import CssTests; @testable import CssResetTests; @testable import HtmlTests; @testable import HtmlCssSupportTests; @testable import HtmlPrettyPrintTests; @testable import HttpPipelineTests; @testable import HttpPipelineHtmlSupportTests; @testable import UrlFormEncodingTests;
 extension ApplicativeRouterHttpPipelineSupportTests {
   static var allTests: [(String, (ApplicativeRouterHttpPipelineSupportTests) -> () throws -> Void)] = [
     ("testRoute", testRoute),

--- a/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
+++ b/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
@@ -118,16 +118,16 @@ final class UrlFormDecoderTests: XCTestCase {
     )
   }
 
-  func testDateDecodingWithFormatted() throws {
-    struct MyDate: Decodable {
-      let date: Date
-    }
-
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US")
-    formatter.setLocalizedDateFormatFromTemplate("MMMMdyyyy")
-
-    decoder.dateDecodingStrategy = .formatted(formatter)
-    assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=December%2031,%202017".utf8)))
-  }
+//  func testDateDecodingWithFormatted() throws {
+//    struct MyDate: Decodable {
+//      let date: Date
+//    }
+//
+//    let formatter = DateFormatter()
+//    formatter.locale = Locale(identifier: "en_US")
+//    formatter.setLocalizedDateFormatFromTemplate("MMMMdyyyy")
+//
+//    decoder.dateDecodingStrategy = .formatted(formatter)
+//    assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=December%2031,%202017".utf8)))
+//  }
 }

--- a/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
+++ b/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
@@ -1,0 +1,133 @@
+import Prelude
+import SnapshotTesting
+import UrlFormEncoding
+import XCTest
+
+final class UrlFormDecoderTests: XCTestCase {
+  let decoder = UrlFormDecoder()
+
+  func testDefaultStrategyAccumulatePairs() throws {
+    struct Foo: Decodable {
+      let x: Int
+      let ys: [Int]
+    }
+
+    assertSnapshot(matching: try decoder.decode(Foo.self, from: Data("x=1&ys=1".utf8)))
+    assertSnapshot(matching: try decoder.decode(Foo.self, from: Data("x=1&ys=1&ys=2".utf8)))
+  }
+
+  func testBrackets() throws {
+    struct Bar: Decodable {
+      let baz: Int
+    }
+
+    struct Foo: Decodable {
+      let helloWorld: String
+      let port: Int
+      let bar: Bar?
+      let bars: [Bar]
+
+      private enum CodingKeys: String, CodingKey {
+        case helloWorld = "hello world"
+        case port
+        case bar
+        case bars
+      }
+    }
+
+    let data = Data(
+      """
+      hello%20world=a%20greeting%20for%20you&port=8080&bars[][baz]=1&bars[][baz]=2&bar=&k&
+      """.utf8
+    )
+
+    decoder.parsingStrategy = .brackets
+    assertSnapshot(matching: try decoder.decode(Foo.self, from: data))
+  }
+
+  func testBracketsWithIndices() throws {
+    struct Bar: Decodable {
+      let baz: Int
+    }
+
+    struct Foo: Decodable {
+      let helloWorld: String
+      let port: Int
+      let bar: Bar?
+      let bars: [Bar]
+
+      private enum CodingKeys: String, CodingKey {
+        case helloWorld = "hello world"
+        case port
+        case bar
+        case bars
+      }
+    }
+
+    let data = Data(
+      """
+      hello%20world=a%20greeting%20for%20you&port=8080&bars[1][baz]=2&bars[0][baz]=1&bar=&k&
+      """.utf8
+    )
+
+    decoder.parsingStrategy = .bracketsWithIndices
+    assertSnapshot(matching: try decoder.decode(Foo.self, from: data))
+  }
+
+  func testDataDecodingWithBase64() throws {
+    struct MyData: Decodable {
+      let data: Data
+    }
+
+    decoder.dataDecodingStrategy = .base64
+    XCTAssertEqual(
+      "OOPs",
+      String(decoding: try decoder.decode(MyData.self, from: Data("data=T09Qcw==".utf8)).data, as: UTF8.self)
+    )
+  }
+
+  func testDateDecodingWithSecondsSince1970() throws {
+    struct MyDate: Decodable {
+      let date: Date
+    }
+
+    decoder.dateDecodingStrategy = .secondsSince1970
+    assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=1513049223".utf8)))
+  }
+
+  func testDateDecodingWithMillisecondsSince1970() throws {
+    struct MyDate: Decodable {
+      let date: Date
+    }
+
+    decoder.dateDecodingStrategy = .secondsSince1970
+    assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=1513049223123".utf8)))
+  }
+
+  func testDateDecodingWithIso8601() throws {
+    struct MyDate: Decodable {
+      let date: Date
+    }
+
+    decoder.dateDecodingStrategy = .iso8601
+    assertSnapshot(
+      matching: try decoder.decode(MyDate.self, from: Data("date=2017-12-11T20:36:00.000-05:00".utf8))
+    )
+    assertSnapshot(
+      matching: try decoder.decode(MyDate.self, from: Data("date=2017-12-11T20:36:00-05:00".utf8))
+    )
+  }
+
+  func testDateDecodingWithFormatted() throws {
+    struct MyDate: Decodable {
+      let date: Date
+    }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US")
+    formatter.setLocalizedDateFormatFromTemplate("MMMMdyyyy")
+
+    decoder.dateDecodingStrategy = .formatted(formatter)
+    assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=December%2031,%202017".utf8)))
+  }
+}

--- a/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
+++ b/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
@@ -100,7 +100,7 @@ final class UrlFormDecoderTests: XCTestCase {
       let date: Date
     }
 
-    decoder.dateDecodingStrategy = .secondsSince1970
+    decoder.dateDecodingStrategy = .millisecondsSince1970
     assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=1513049223123".utf8)))
   }
 

--- a/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
+++ b/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
@@ -6,6 +6,14 @@ import XCTest
 final class UrlFormDecoderTests: XCTestCase {
   let decoder = UrlFormDecoder()
 
+  func testOptionality() throws {
+    struct Foo: Decodable {
+      let x: Int?
+    }
+
+    XCTAssertNil(try decoder.decode(Foo.self, from: Data()).x)
+  }
+
   func testDefaultStrategyAccumulatePairs() throws {
     struct Foo: Decodable {
       let x: Int
@@ -26,22 +34,32 @@ final class UrlFormDecoderTests: XCTestCase {
       let port: Int
       let bar: Bar?
       let bars: [Bar]
+      let barses: [[Bar]]
 
       private enum CodingKeys: String, CodingKey {
         case helloWorld = "hello world"
         case port
         case bar
         case bars
+        case barses
       }
     }
 
     let data = Data(
       """
-      hello%20world=a%20greeting%20for%20you&port=8080&bars[][baz]=1&bars[][baz]=2&bar=&k&
+      hello%20world=a%20greeting%20for%20you&\
+      port=8080&\
+      bars[][baz]=1&\
+      bars[][baz]=2&\
+      bar=&\
+      barses[][][baz]=3&\
+      barses[][][baz]=4&\
+      k&&
       """.utf8
     )
 
     decoder.parsingStrategy = .brackets
+
     assertSnapshot(matching: try decoder.decode(Foo.self, from: data))
   }
 
@@ -71,6 +89,7 @@ final class UrlFormDecoderTests: XCTestCase {
     )
 
     decoder.parsingStrategy = .bracketsWithIndices
+
     assertSnapshot(matching: try decoder.decode(Foo.self, from: data))
   }
 
@@ -80,6 +99,7 @@ final class UrlFormDecoderTests: XCTestCase {
     }
 
     decoder.dataDecodingStrategy = .base64
+
     XCTAssertEqual(
       "OOPs",
       String(decoding: try decoder.decode(MyData.self, from: Data("data=T09Qcw==".utf8)).data, as: UTF8.self)
@@ -92,6 +112,7 @@ final class UrlFormDecoderTests: XCTestCase {
     }
 
     decoder.dateDecodingStrategy = .secondsSince1970
+
     assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=1513049223".utf8)))
   }
 
@@ -101,6 +122,7 @@ final class UrlFormDecoderTests: XCTestCase {
     }
 
     decoder.dateDecodingStrategy = .millisecondsSince1970
+
     assertSnapshot(matching: try decoder.decode(MyDate.self, from: Data("date=1513049223123".utf8)))
   }
 
@@ -110,6 +132,7 @@ final class UrlFormDecoderTests: XCTestCase {
     }
 
     decoder.dateDecodingStrategy = .iso8601
+
     assertSnapshot(
       matching: try decoder.decode(MyDate.self, from: Data("date=2017-12-11T20:36:00.000-05:00".utf8))
     )

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBrackets.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBrackets.1.txt
@@ -1,0 +1,9 @@
+▿ Foo #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
+  - helloWorld: "a greeting for you"
+  - port: 8080
+  - bar: nil
+  ▿ bars: 2 elements
+    ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
+      - baz: 1
+    ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
+      - baz: 2

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBrackets.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBrackets.1.txt
@@ -7,3 +7,10 @@
       - baz: 1
     ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
       - baz: 2
+  ▿ barses: 2 elements
+    ▿ 1 element
+      ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
+        - baz: 3
+    ▿ 1 element
+      ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBrackets() throws -> ()
+        - baz: 4

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBracketsWithIndices.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testBracketsWithIndices.1.txt
@@ -1,0 +1,9 @@
+▿ Foo #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBracketsWithIndices() throws -> ()
+  - helloWorld: "a greeting for you"
+  - port: 8080
+  - bar: nil
+  ▿ bars: 2 elements
+    ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBracketsWithIndices() throws -> ()
+      - baz: 1
+    ▿ Bar #1 in UrlFormEncodingTests.UrlFormDecoderTests.testBracketsWithIndices() throws -> ()
+      - baz: 2

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithFormatted.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithFormatted.1.txt
@@ -1,0 +1,3 @@
+▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithFormatted() throws -> ()
+  ▿ date: 2017-12-31 05:00:00 +0000
+    - timeIntervalSinceReferenceDate: 536389200.0

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithIso8601.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithIso8601.1.txt
@@ -1,0 +1,3 @@
+▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithIso8601() throws -> ()
+  ▿ date: 2017-12-12 01:36:00 +0000
+    - timeIntervalSinceReferenceDate: 534735360.0

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithIso8601.2.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithIso8601.2.txt
@@ -1,0 +1,3 @@
+▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithIso8601() throws -> ()
+  ▿ date: 2017-12-12 01:36:00 +0000
+    - timeIntervalSinceReferenceDate: 534735360.0

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithMillisecondsSince1970.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithMillisecondsSince1970.1.txt
@@ -1,0 +1,3 @@
+▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithMillisecondsSince1970() throws -> ()
+  ▿ date: 49916-08-15 18:52:03 +0000
+    - timeIntervalSinceReferenceDate: 1512070915923.0

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithMillisecondsSince1970.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithMillisecondsSince1970.1.txt
@@ -1,3 +1,3 @@
 ▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithMillisecondsSince1970() throws -> ()
-  ▿ date: 49916-08-15 18:52:03 +0000
-    - timeIntervalSinceReferenceDate: 1512070915923.0
+  ▿ date: 2017-12-12 03:27:03 +0000
+    - timeIntervalSinceReferenceDate: 534742023.12299991

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithSecondsSince1970.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDateDecodingWithSecondsSince1970.1.txt
@@ -1,0 +1,3 @@
+▿ MyDate #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDateDecodingWithSecondsSince1970() throws -> ()
+  ▿ date: 2017-12-12 03:27:03 +0000
+    - timeIntervalSinceReferenceDate: 534742023.0

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDefaultStrategyAccumulatePairs.1.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDefaultStrategyAccumulatePairs.1.txt
@@ -1,0 +1,4 @@
+▿ Foo #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDefaultStrategyAccumulatePairs() throws -> ()
+  - x: 1
+  ▿ ys: 1 element
+    - 1

--- a/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDefaultStrategyAccumulatePairs.2.txt
+++ b/Tests/UrlFormEncodingTests/__Snapshots__/UrlFormDecoderTests/testDefaultStrategyAccumulatePairs.2.txt
@@ -1,0 +1,5 @@
+▿ Foo #1 in UrlFormEncodingTests.UrlFormDecoderTests.testDefaultStrategyAccumulatePairs() throws -> ()
+  - x: 1
+  ▿ ys: 2 elements
+    - 1
+    - 2


### PR DESCRIPTION
Our router has been very naively converting form data and query strings to `[String: String]`, which leads to a lot of extra manual parsing. While form data is typically thought of as a dictionary-like structure, this is a lossy format and key collisions make `[(String, String)]` a more accurate format. Because of this, different frameworks and services have adopted different key and value encodings to accommodate things like arrays and nested structure.

The most agnostic parser may work as follows:

``` swift
parse("xs=1&xs=2") == ["xs": ["1", "2"]] // true
```

Meanwhile, other parsers support bracketed and index-bracketed values:

``` swift
parse("xs[]=1&xs[]=2&roots[][value]=hello&roots[][value]=world")
  == ["xs": ["1", "2"], "roots": [["value": "hello"], ["value": "world"]]]
// or, with indices:
parse("xs[0]=1&xs[1]=2&roots[1][value]=world&roots[0][value]=hello")
  == ["xs": ["1", "2"], "roots": [["value": "hello"], ["value": "world"]]]
```

Still—and beyond the scope of this PR at the time of submitting—other parsers may favor array values by comma-separation!

``` swift
parse("xs=1,2") == ["xs": ["1", "2"]]
```

Even after all this, you're left with a tree of `[String: Any]` where the `Any` node eventually reaches `String`, so you inevitably have to parse further to get the data into its proper format.

This PR leverages `Decodable` to automatically convert form data and query strings into structures that we can work with immediately. It makes a best effort to convert each string value to its expected type.

- `"1"` becomes `1` when an `Int` (or any other number type) is expected.
- `"2.3"` becomes `2.3` as a `Float` or `Double` accordingly.
- `Date`- and `Data`-decoding strategies exist, to automatically hydrate the expected type.
- For nested parsing strategies, deep and complex structures can be decoded!

I'll add a quick self-review to highlight some tested examples.