### PR TITLE
Add escape hatch to unencoded string.

### DIFF
--- a/Sources/Html/EncodedString.swift
+++ b/Sources/Html/EncodedString.swift
@@ -24,6 +24,10 @@ extension EncodedString: Monoid {
   }
 }
 
+public func unsafeUnencodedString(_ string: String) -> EncodedString {
+  return EncodedString(string)
+}
+
 public func quote(_ string: EncodedString) -> EncodedString {
   return .init("\"" + string.string + "\"")
 }

--- a/Tests/HtmlTests/EncodedStringTests.swift
+++ b/Tests/HtmlTests/EncodedStringTests.swift
@@ -48,4 +48,11 @@ class EncodedStringTests: XCTestCase {
       render(node)
     )
   }
+
+  func testUnsafeUnencodedString() {
+    XCTAssertEqual(
+      "<p>Point&#8209;Free</p>",
+      render(p(["Point", .text(unsafeUnencodedString("&#8209;")), "Free"]))
+    )
+  }
 }


### PR DESCRIPTION
We need an escape hatch to use unescaped strings, so adding this.

The main reason I need this is that we have a `@testable import` in `pointfreeco`, which prevents me from building on linux. I would use this to use a non-breaking hyphen `&#8209;`