### PR TITLE
Transform form data "+" to " "

### DIFF
--- a/Sources/UrlFormEncoding/UrlFormDecoder.swift
+++ b/Sources/UrlFormEncoding/UrlFormDecoder.swift
@@ -735,7 +735,11 @@ private func pairs(_ query: String, sort: Bool = false) -> [(String, String?)] {
     .split(separator: "&")
     .map { (pairString: Substring) -> (name: String, value: String?) in
       let pairArray = pairString.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-        .flatMap(String.init >>> ^\.removingPercentEncoding)
+        .flatMap(
+          String.init
+            >>> { $0.replacingOccurrences(of: "+", with: " ") }
+            >>> ^\.removingPercentEncoding
+      )
       return (pairArray[0], pairArray.count == 2 ? pairArray[1] : nil)
     }
 

--- a/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
+++ b/Tests/UrlFormEncodingTests/UrlFormDecoderTests.swift
@@ -16,6 +16,14 @@ final class UrlFormDecoderTests: XCTestCase {
     XCTAssertEqual(1, try decoder.decode(Foo.self, from: Data("x=1".utf8)).x)
   }
 
+  func testPlusses() throws {
+    struct Foo: Decodable {
+      let x: String
+    }
+
+    XCTAssertEqual("hello world", try decoder.decode(Foo.self, from: Data("x=hello+world".utf8)).x)
+  }
+
   func testDefaultStrategyAccumulatePairs() throws {
     struct Foo: Decodable {
       let x: Int


### PR DESCRIPTION
Surprised we didn't hit this sooner! After setting up Point-Free's profile update endpoint, I was greeted with this:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/658/34286212-27694322-e6ad-11e7-9b0f-034203fa2b0a.png">

Looks like we have to translate this manually, as browsers plus-encode space in form data.