### PR TITLE
Router.absoluteString(for:) should maybe return nil

### DIFF
--- a/Sources/ApplicativeRouter/SyntaxRouter.swift
+++ b/Sources/ApplicativeRouter/SyntaxRouter.swift
@@ -39,8 +39,8 @@ public struct Router<A> {
     return self.print(a).flatMap { ApplicativeRouter.request(from: $0, base: base) }.flatMap { $0.url }
   }
 
-  public func absoluteString(for a: A) -> String {
-    return "/" + (url(for: a)?.absoluteString ?? "")
+  public func absoluteString(for a: A) -> String? {
+    return url(for: a).map { "/" + $0.absoluteString }
   }
 
   public func templateRequest(for a: A) -> URLRequest? {


### PR DESCRIPTION
If a router doesn't handle a route, it returns `"/"`, which is a bit of a gotcha. Apps can wrap this function with `url(to:)` and `path(to:)` helpers that handle the `nil` case and are free to call `assertionFailure`s in development.