### PR TITLE
Redirect helper

### DIFF
--- a/Sources/HttpPipeline/Middleware.swift
+++ b/Sources/HttpPipeline/Middleware.swift
@@ -57,12 +57,13 @@ public func end<A>(conn: Conn<HeadersOpen, A>) -> IO<Conn<ResponseEnded, Data>> 
 
 public func redirect<A>(
   to location: String,
+  status: Status = .found,
   headersMiddleware: @escaping Middleware<HeadersOpen, HeadersOpen, A, A> = (id >>> pure)
   )
   ->
   Middleware<StatusLineOpen, ResponseEnded, A, Data> {
 
-    return writeStatus(.found)
+    return writeStatus(status)
       >-> headersMiddleware
       >-> writeHeader(.location(location))
       >-> end

--- a/Sources/HttpPipeline/Response.swift
+++ b/Sources/HttpPipeline/Response.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MediaType
+import Optics
 import Prelude
 
 public struct Response {
@@ -138,9 +139,6 @@ public struct Response {
   }
 }
 
-private let expiresDateFormatter: DateFormatter = { () -> DateFormatter in
-  let formatter = DateFormatter()
-  formatter.timeZone = TimeZone(abbreviation: "UTC")
-  formatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss zzz"
-  return formatter
-}()
+private let expiresDateFormatter = DateFormatter()
+  |> \.dateFormat .~ "EEE, d MMM yyyy HH:mm:ss zzz"
+  |> \.timeZone .~ TimeZone(abbreviation: "UTC")

--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -84,12 +84,7 @@ public func redirectUnrelatedHosts<A>(
               |> map(\.host .~ canonicalHost)
           }
           .flatMap(^\.url)
-          .map {
-            conn
-              |> writeStatus(.movedPermanently)
-              >-> writeHeader(.location($0.absoluteString))
-              >-> end
-          }
+          .map { conn |> redirect(to: $0.absoluteString, status: .movedPermanently) }
           ?? middleware(conn)
       }
     }
@@ -109,12 +104,7 @@ public func requireHerokuHttps<A>(allowedInsecureHosts: [String])
               && !allowedInsecureHosts.contains(url.host ?? "")
           }
           .flatMap(makeHttps)
-          .map {
-            conn
-              |> writeStatus(.movedPermanently)
-              >-> writeHeader(.location($0.absoluteString))
-              >-> end
-          }
+          .map { conn |> redirect(to: $0.absoluteString, status: .movedPermanently) }
           ?? middleware(conn)
       }
     }
@@ -132,12 +122,7 @@ public func requireHttps<A>(allowedInsecureHosts: [String])
               && !allowedInsecureHosts.contains(url.host ?? "")
           }
           .flatMap(makeHttps)
-          .map {
-            conn
-              |> writeStatus(.movedPermanently)
-              >-> writeHeader(.location($0.absoluteString))
-              >-> end
-          }
+          .map { conn |> redirect(to: $0.absoluteString, status: .movedPermanently) }
           ?? middleware(conn)
       }
     }


### PR DESCRIPTION
Small commit allowing `redirect` to be passed a status.

Future exploration: our `enum Status` should probably become a `struct`, at which point we could even do something interesting with phantom types like:

``` swift
struct Status<Category> {
  let code: Int
  // …
  public static var ok: Status<Success> { return .init(code: 200) }
  // …
  public static var found: Status<Redirect> { return .init(code: 302) }
}

func redirect(to: String, status: Status<Redirect> = .found) -> // …
```

This would bleed up into, potentially, an extra generic param on `Conn`, though, which might allow for interesting things! Then again, maybe not worth it! Alternatively we could just assert in `redirect`:

``` swift
assert((300...400).contains(status.code))
```