### PR TITLE
Guard against all fatalErrors in Cryptor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
         "state": {
           "branch": null,
-          "revision": "16f9c7ddcbe11bbd32106a791ebef2108a4e9183",
-          "version": "0.8.21"
+          "revision": "1de800d80f22a930e617f7c551a692475f92a23d",
+          "version": "0.8.22"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("9a635ce")),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .revision("c510e7d")),
     .package(url: "https://github.com/bkase/DoctorPretty.git", .exact("0.4.1")),
-    .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .exact("0.8.21"))
+    .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .exact("0.8.22"))
   ],
   targets: [
     .target(name: "ApplicativeRouter", dependencies: ["Either", "Optics", "Prelude", "UrlFormEncoding"]),

--- a/Sources/HttpPipeline/SignedCookies.swift
+++ b/Sources/HttpPipeline/SignedCookies.swift
@@ -112,7 +112,14 @@ public func digest(value: String, secret: String) -> String? {
   return digestBytes.map { Data(bytes: $0).base64EncodedString() }
 }
 
+private let nonHexCharacterSet = CharacterSet(charactersIn: "0123456789abcdefABCDEF").inverted
+
 public func encrypted(text plainText: String, secret: String) -> String? {
+  // NB: Cryptor fatalErrros if secret isn't 32 characters long.
+  guard secret.count == 32 else { return nil }
+  // NB: Cryptor fatalErrors if secret contains non-hex digits.
+  guard secret.rangeOfCharacter(from: nonHexCharacterSet) == nil else { return nil }
+
   let secretBytes = CryptoUtils.byteArray(fromHex: secret)
   let iv = [UInt8](repeating: 0, count: secretBytes.count)
   let plainTextBytes = CryptoUtils.byteArray(from: plainText)
@@ -130,6 +137,15 @@ public func encrypted(text plainText: String, secret: String) -> String? {
 }
 
 public func decrypted(text encryptedText: String, secret: String) -> String? {
+  // NB: Cryptor fatalErrros if secret isn't 32 characters long.
+  guard secret.count == 32 else { return nil }
+  // NB: Cryptor fatalErrors if secret contains non-hex digits.
+  guard secret.rangeOfCharacter(from: nonHexCharacterSet) == nil else { return nil }
+  // NB: Cryptor fatalErrors if `encryptedText` contains non-hex digits.
+  guard encryptedText.rangeOfCharacter(from: nonHexCharacterSet) == nil else { return nil }
+  // NB: Cryptor fatalErrros if `encryptedText` has an odd number of characters.
+  guard encryptedText.count % 2 == 0 else { return nil }
+  
   let secretBytes = CryptoUtils.byteArray(fromHex: secret)
   let iv = [UInt8](repeating: 0, count: secretBytes.count)
   let encryptedTextBytes = CryptoUtils.byteArray(fromHex: encryptedText)

--- a/Tests/HttpPipelineTests/EncryptionTests.swift
+++ b/Tests/HttpPipelineTests/EncryptionTests.swift
@@ -1,0 +1,30 @@
+import Deriving
+import HttpPipeline
+import HttpPipelineTestSupport
+import Optics
+import Prelude
+import SnapshotTesting
+import XCTest
+
+class EncryptionTests: XCTestCase {
+
+  func testEncrypt() {
+    XCTAssertEqual("af54a6cf18a83a6dc0a38e2895dd1ce4", encrypted(text: "blah", secret: "DeadBeefDeadBeef0123012301230123"))
+
+    XCTAssertNil(encrypted(text: "blah", secret: "deadbeefdeadbeef"))
+    XCTAssertNil(encrypted(text: "blah", secret: "asdfasdfasdfasdfasdfasdfasdfasdf"))
+  }
+
+  func testDecrypt() {
+    XCTAssertEqual("blah", decrypted(text: "af54a6cf18a83a6dc0a38e2895dd1ce4", secret: "DeadBeefDeadBeef0123012301230123"))
+
+    XCTAssertNil(decrypted(text: "836fdf1bf0008e1be7b352d0ccd42dcb", secret: "deadbeefdeadbeef"))
+    XCTAssertNil(decrypted(text: "8", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
+    XCTAssertNil(decrypted(text: "83", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
+    XCTAssertNil(decrypted(text: "asdf", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
+  }
+
+  func testDigest() {
+    XCTAssertNotNil(digest(value: "ZNeX1idK+rOYKu9jcq7AS9+IBA3wuPWWZeUQchQrLIs=", secret: "deadbeef"))
+  }
+}

--- a/Tests/HttpPipelineTests/EncryptionTests.swift
+++ b/Tests/HttpPipelineTests/EncryptionTests.swift
@@ -6,16 +6,29 @@ class EncryptionTests: XCTestCase {
   func testEncrypt() {
     XCTAssertEqual("af54a6cf18a83a6dc0a38e2895dd1ce4", encrypted(text: "blah", secret: "DeadBeefDeadBeef0123012301230123"))
 
+    // Secret is too short
     XCTAssertNil(encrypted(text: "blah", secret: "deadbeefdeadbeef"))
+
+    // Secret is not valid hex string
     XCTAssertNil(encrypted(text: "blah", secret: "asdfasdfasdfasdfasdfasdfasdfasdf"))
   }
 
   func testDecrypt() {
     XCTAssertEqual("blah", decrypted(text: "af54a6cf18a83a6dc0a38e2895dd1ce4", secret: "DeadBeefDeadBeef0123012301230123"))
 
+    // Secret is too short
     XCTAssertNil(decrypted(text: "836fdf1bf0008e1be7b352d0ccd42dcb", secret: "deadbeefdeadbeef"))
+
+    // Secret is not valid hex string
+    XCTAssertNil(decrypted(text: "836fdf1bf0008e1be7b352d0ccd42dcb", secret: "asdfasdfasdfasdfasdfasdfasdfasdf"))
+
+    // Encrypted text is not even length
     XCTAssertNil(decrypted(text: "8", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
+
+    // Encrypted text is not valid.
     XCTAssertNil(decrypted(text: "83", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
+
+    // Encrypted text is not valid hex string.
     XCTAssertNil(decrypted(text: "asdf", secret: "deadbeefdeadbeefdeadbeefdeadbeef"))
   }
 

--- a/Tests/HttpPipelineTests/EncryptionTests.swift
+++ b/Tests/HttpPipelineTests/EncryptionTests.swift
@@ -1,9 +1,4 @@
-import Deriving
 import HttpPipeline
-import HttpPipelineTestSupport
-import Optics
-import Prelude
-import SnapshotTesting
 import XCTest
 
 class EncryptionTests: XCTestCase {

--- a/Tests/HttpPipelineTests/EncryptionTests.swift
+++ b/Tests/HttpPipelineTests/EncryptionTests.swift
@@ -2,7 +2,6 @@ import HttpPipeline
 import XCTest
 
 class EncryptionTests: XCTestCase {
-
   func testEncrypt() {
     XCTAssertEqual("af54a6cf18a83a6dc0a38e2895dd1ce4", encrypted(text: "blah", secret: "DeadBeefDeadBeef0123012301230123"))
 

--- a/Tests/HttpPipelineTests/SignedCookieTests.swift
+++ b/Tests/HttpPipelineTests/SignedCookieTests.swift
@@ -147,7 +147,7 @@ cb4db8ac9390ac810837809f11bc6803\
   }
 }
 
-struct Episode: Codable, DerivingEquatable {
+private struct Episode: Codable, DerivingEquatable {
   let id: Int
   let name: String
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -70,6 +70,13 @@ extension EncodedStringTests {
     ("testUnsafeUnencodedString", testUnsafeUnencodedString)
   ]
 }
+extension EncryptionTests {
+  static var allTests: [(String, (EncryptionTests) -> () throws -> Void)] = [
+    ("testEncrypt", testEncrypt),
+    ("testDecrypt", testDecrypt),
+    ("testDigest", testDigest)
+  ]
+}
 extension FlexBoxTests {
   static var allTests: [(String, (FlexBoxTests) -> () throws -> Void)] = [
     ("testFlexBox", testFlexBox)
@@ -234,6 +241,7 @@ XCTMain([
   testCase(BorderTests.allTests),
   testCase(CssRenderTests.allTests),
   testCase(EncodedStringTests.allTests),
+  testCase(EncryptionTests.allTests),
   testCase(FlexBoxTests.allTests),
   testCase(FullDocumentTests.allTests),
   testCase(FullStylesheetTests.allTests),


### PR DESCRIPTION
[Cryptor](https://github.com/IBM-Swift/BlueCryptor/) has a lot of `fatalError`s, so let's guard against them and just return `nil`.

I've opened an issue here https://github.com/IBM-Swift/BlueCryptor/issues/30 about this.