### PR TITLE
conform Node to Sequence

### DIFF
--- a/Sources/Html/Html.swift
+++ b/Sources/Html/Html.swift
@@ -18,6 +18,30 @@ extension Node: ExpressibleByStringLiteral {
   }
 }
 
+extension Node: Sequence {
+  public func makeIterator() -> AnyIterator<Node> {
+    var stack = [self]
+
+    return AnyIterator<Node> {
+      guard let next = stack.popLast() else {
+        return nil
+      }
+      switch next {
+      case .comment, .text:
+        return next
+      case  .element(let element):
+        if let content = element.content {
+          stack.append(contentsOf: content.reversed())
+        }
+        return next
+      case .document(let nodes):
+        stack.append(contentsOf: nodes.reversed())
+        return next
+      }
+    }
+  }
+}
+
 public struct ChildOf<T> {
   public let node: Node
 

--- a/Tests/HtmlTests/HtmlTests.swift
+++ b/Tests/HtmlTests/HtmlTests.swift
@@ -214,4 +214,40 @@ class HTMLTests: XCTestCase {
     let checkedInput = input([id("checked"), checked(true)])
     XCTAssertEqual("<input id=\"checked\" checked>", render(checkedInput))
   }
+
+  func testSequenceConformance() {
+    let doc = document([
+      html([
+        head([
+          title("Title")
+        ]),
+        body([
+          comment("Comment")
+        ])
+      ])
+    ])
+
+    let descriptions = doc.map { (node) -> String in
+      switch node {
+      case .comment(let content):
+        return "comment: \(content.string)"
+      case .document:
+        return "document"
+      case .element(let elem):
+        return "element: \(elem.name)"
+      case .text(let content):
+        return "text: \(content.string)"
+      }
+    }
+
+    XCTAssertEqual(descriptions, [
+      "document",
+      "element: html",
+      "element: head",
+      "element: title",
+      "text: Title",
+      "element: body",
+      "comment: Comment"
+    ])
+  }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -104,7 +104,8 @@ extension HTMLTests {
     ("testPrettyRender", testPrettyRender),
     ("testDocument", testDocument),
     ("testTables", testTables),
-    ("testBooleanAttributes", testBooleanAttributes)
+    ("testBooleanAttributes", testBooleanAttributes),
+    ("testSequenceConformance", testSequenceConformance)
   ]
 }
 extension HtmlRenderTests {


### PR DESCRIPTION
Closes #37 

@mbrandonw, I'm not sure if this is what you had in mind, but I thought I'd give it a shot. 

Iterates through child `Nodes` contained in `.document` and `.element` using depth-first strategy. `Node.comment` and `.text` are considered sequences of one element, `self`.