### PR TITLE
Use en_US_POSIX locale for cookie formatting

### DIFF
--- a/Sources/HttpPipeline/Response.swift
+++ b/Sources/HttpPipeline/Response.swift
@@ -142,4 +142,5 @@ public struct Response {
 
 private let expiresDateFormatter = DateFormatter()
   |> \.dateFormat .~ "EEE, d MMM yyyy HH:mm:ss zzz"
+  |> \.locale .~ Locale(identifier: "en_US_POSIX")
   |> \.timeZone .~ TimeZone(abbreviation: "UTC")


### PR DESCRIPTION
Fixes #135.