### PR TITLE
Fix pretty renderer for "pre" elements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
         "package": "Prelude",
         "repositoryURL": "https://github.com/pointfreeco/swift-prelude.git",
         "state": {
-          "branch": "536b885",
-          "revision": "536b8856e38853854b5c5689e5b5d06da75c992e",
+          "branch": "5d5005d",
+          "revision": "5d5005d0fc0c0292725054d005b6a4be9ad0ae0c",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .library(name: "UrlFormEncoding", targets: ["UrlFormEncoding"]),
     ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("536b885")),
+    .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("5d5005d")),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .revision("69b48c8")),
     .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
     .package(url: "https://github.com/bkase/DoctorPretty.git", from: "0.5.0"),

--- a/Sources/Html/Render.swift
+++ b/Sources/Html/Render.swift
@@ -35,12 +35,8 @@ public func render(_ node: Node, config: Config = .compact) -> String {
           $0.map {
             realRender(
               $0,
-              config: element.name == "pre"
-                ? Config(indentation: "", newline: config.newline)
-                : config,
-              indentation: element.name == "pre"
-                ? ""
-                : indentation + config.indentation
+              config: element.name == "pre" ? .compact : config,
+              indentation: element.name == "pre" ? "" : indentation + config.indentation
             )
           }
         }?.joined()

--- a/Sources/Html/Render.swift
+++ b/Sources/Html/Render.swift
@@ -35,8 +35,12 @@ public func render(_ node: Node, config: Config = .compact) -> String {
           $0.map {
             realRender(
               $0,
-              config: config,
-              indentation: indentation + config.indentation
+              config: element.name == "pre"
+                ? Config(indentation: "", newline: config.newline)
+                : config,
+              indentation: element.name == "pre"
+                ? ""
+                : indentation + config.indentation
             )
           }
         }?.joined()


### PR DESCRIPTION
This fixes pretty HTML rendering for `pre` elements, which need to not be prefixed with whitespace since they preserve it.