### PR TITLE
Add Default Strict-Transport-Security Header

### DIFF
--- a/Sources/HttpPipeline/Conn.swift
+++ b/Sources/HttpPipeline/Conn.swift
@@ -17,7 +17,7 @@ public func connection(
   defaultHeaders headers: [Response.Header] = [
 //  .init("Content-Security-Policy", "script-src 'unsafe-inline'; style-src 'unsafe-inline'"),
   .init("Referrer-Policy", "strict-origin-when-cross-origin"),
-  .init("Strict-Transport-Security", "max-age=63072000"),
+  .init("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload"),
   .init("X-Content-Type-Options", "nosniff"),
   .init("X-Download-Options", "noopen"),
   .init("X-Frame-Options", "SAMEORIGIN"),

--- a/Sources/HttpPipeline/Conn.swift
+++ b/Sources/HttpPipeline/Conn.swift
@@ -17,6 +17,7 @@ public func connection(
   defaultHeaders headers: [Response.Header] = [
 //  .init("Content-Security-Policy", "script-src 'unsafe-inline'; style-src 'unsafe-inline'"),
   .init("Referrer-Policy", "strict-origin-when-cross-origin"),
+  .init("Strict-Transport-Security", "max-age=63072000"),
   .init("X-Content-Type-Options", "nosniff"),
   .init("X-Download-Options", "noopen"),
   .init("X-Frame-Options", "SAMEORIGIN"),


### PR DESCRIPTION
For your consideration: 

This patch adds the following header as a default response header:

```
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
```

The effect of this is header is that browsers can only connect to the site via HTTPS for the next two years (the generally recommended timeframe for HSTS). Point-Free is [already requires HTTPS in its middleware](https://github.com/pointfreeco/pointfreeco/blob/31aad7f86e9e05a490d39d2472eb90b9c3e56ab1/Sources/PointFree/SiteMiddleware.swift#L13), so this header just formalizes a requirement already in place, and ensures that users never connect insecurely to the website.

From [Mozilla's Security Guidelines page](https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security):

> HTTP Strict Transport Security (HSTS) is an HTTP header that notifies user agents to only connect to a given site over HTTPS, even if the scheme chosen was HTTP. Browsers that have had HSTS set for a given site will transparently upgrade all requests to HTTPS. HSTS also tells the browser to treat TLS and certificate-related errors more strictly by disabling the ability for users to bypass the error page.

By adding this header, you can submit <pointfree.co> to the [HSTS preload list](https://hstspreload.org), which ensures that browsers only connect via a secure connection.

There are a few things to consider before adopting this header as-is:

* You should review the [hstspreload.org deployment recommendations](https://hstspreload.org/#deployment-recommendations) to ensure that everything works as expected.
* This may impact local development requirements. The use of locally-issued certificates is becoming more widespread as HTTPS becomes ubiquitous. For more information about that process, check out [this article from Let's Encrypt](https://letsencrypt.org/docs/certificates-for-localhost/).