### PR TITLE
Add contentSecurityPolicy Case to HttpEquiv Enumeration

### DIFF
--- a/Sources/Html/Attributes.swift
+++ b/Sources/Html/Attributes.swift
@@ -189,6 +189,7 @@ public func mailto<T: HasHref>(_ address: String) -> Attribute<T> {
 
 public enum HttpEquiv: String, Value {
   case contentType = "content-type"
+  case contentSecurityPolicy = "content-security-policy"
   case defaultStyle = "default-style"
   case refresh = "refresh"
 }


### PR DESCRIPTION
Related to #152, another modern web standard that you can use to improve the security of <https://pointfree.co> is to define a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).

A CSP can be defined either in an HTTP header or a `<meta>` tag. I couldn't find a straightforward way to add a new default header to connections serving HTML responses, so I went with a `<meta>` tag.

To do this, I added a new `contentSecurityPolicy` case to the `HttpEquiv` enumeration. With this in place, you could update your standard layout to include a new `meta` tag.

As far as defining a CSP, the easiest way would be to simply hardcode a string. As an alternative, you might also consider [this DSL I created](https://github.com/ReadEval/ContentSecurityPolicy).

I haven't tested this myself, but I believe that the following CSP would be valid for <https://pointfree.co>:

```
default-src 'self' *.pointfree.co;
script-src 'self' *.pointfree.co 'unsafe-inline' https://www.google-analytics.com;
connect-src 'self' *.pointfree.co https://www.google-analytics.com;
base-uri 'none';
upgrade-insecure-requests;
```