### PR TITLE
Pretty print void element children.

### DIFF
--- a/Sources/HtmlPrettyPrint/Pretty.swift
+++ b/Sources/HtmlPrettyPrint/Pretty.swift
@@ -52,7 +52,7 @@ public func prettyPrint(_ node: Node, config: Config = .pretty) -> String {
           }
         }
         .joined(separator: config.newline + indentation + String(repeating: " ", count: tag.count + 1))
-      guard !voidElements.contains(tag) else {
+      guard !children.isEmpty || !voidElements.contains(tag) else {
         return indentation + "<" + tag + renderedAttrs + ">" + config.newline
       }
       return indentation + "<" + tag + renderedAttrs + ">" + config.newline

--- a/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
+++ b/Tests/HtmlPrettyPrintTests/HtmlPrettyPrintTests.swift
@@ -133,4 +133,16 @@ composition.
 
     assertSnapshot(matching: doc)
   }
+
+  func testVoidElementsWithChildren() {
+    let doc = element("link", [.init("href", "https://www.pointfree.co") as Attribute<Void>], [""])
+
+    XCTAssertEqual("""
+<link href="https://www.pointfree.co">
+  \
+
+</link>
+
+""", prettyPrint(doc))
+  }
 }


### PR DESCRIPTION
Currently in the `render` on swift-html we will render the children of void elements if there are some:

https://github.com/pointfreeco/swift-html/blob/630aa9da091be1b1db1d2ce3c83796074808c60e/Sources/Html/Render.swift#L20

I don't know if that was done by design, but I do think it's a necessary escape hatch as I have shown in this issue on pointfreeco:

https://github.com/pointfreeco/pointfreeco/issues/335

All this PR does is port that behavior over to `prettyPrint`.

