### PR TITLE
Specify a base url to prevent early closes.

### DIFF
--- a/Sources/HttpPipeline/NIO.swift
+++ b/Sources/HttpPipeline/NIO.swift
@@ -79,7 +79,9 @@ private final class Handler: ChannelInboundHandler {
           status: .init(statusCode: 307),
           headers: .init([("location", self.baseUrl.absoluteString)])
         )))
-        _ = ctx.channel.close()
+        _ = ctx.channel.writeAndFlush(HTTPServerResponsePart.end(nil)).then {
+          ctx.channel.close()
+        }
         return
       }
 


### PR DESCRIPTION
It's pretty easy to construct a bad URL that Foundation chokes on, and that causes us to close the NIO channel early. Let's prevent this from happening by redirecting to the base URL.

A longer term fix would be to pass in an entire response that can be used so that we can do a 50X response with a custom view. And even more long term would be to stop using foundation for `URL` and `URLRequest`.