### PR TITLE
Bump Dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-prelude.git", .revision("8cbc934")),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-html", from: "0.2.1"),
-    .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
-    .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .exact("1.0.4")),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "1.13.0"),
+    .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .exact("1.0.23")),
   ],
   targets: [
     .target(name: "ApplicativeRouter", dependencies: ["Either", "Optics", "Prelude", "UrlFormEncoding"]),


### PR DESCRIPTION
We're on an old version of BlueCryptor that is still on Swift 3.1, which isn't supported by Swift 5.