### PR TITLE
allow basic auth even if header is lowercased

### DIFF
--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -160,7 +160,7 @@ public func requireHttps<A>(allowedInsecureHosts: [String])
 
 public func validateBasicAuth(user: String, password: String, request: URLRequest) -> Bool {
 
-  let auth = request.allHTTPHeaderFields?.first(where: { $0.key == "Authorization" })?.value ?? ""
+  let auth = request.allHTTPHeaderFields?.first(where: { $0.key.lowercased() == "authorization" })?.value ?? ""
 
   let parts = Foundation.Data(base64Encoded: String(auth.dropFirst(6)))
     .map { String(decoding: $0, as: UTF8.self) }

--- a/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
+++ b/Sources/HttpPipeline/SharedMiddlewareTransformers.swift
@@ -160,7 +160,7 @@ public func requireHttps<A>(allowedInsecureHosts: [String])
 
 public func validateBasicAuth(user: String, password: String, request: URLRequest) -> Bool {
 
-  let auth = request.allHTTPHeaderFields?.first(where: { $0.key.lowercased() == "authorization" })?.value ?? ""
+  let auth = request.value(forHTTPHeaderField: "Authorization") ?? ""
 
   let parts = Foundation.Data(base64Encoded: String(auth.dropFirst(6)))
     .map { String(decoding: $0, as: UTF8.self) }

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -183,7 +183,7 @@ class SharedMiddlewareTransformersTests: SnapshotTestCase {
     assertSnapshot(matching: log, as: .dump)
   }
   
-  func testBasiAuthValidationIsCaseInsensitive() {
+  func testBasicAuthValidationIsCaseInsensitive() {
     let urlRequestWithUppercaseAuthorizationHeader = URLRequest(url: URL(string: "/")!)
       |> \.allHTTPHeaderFields .~ ["Authorization": "Basic SGVsbG86V29ybGQ="]
     XCTAssertTrue(validateBasicAuth(user: "Hello", password: "World", request: urlRequestWithUppercaseAuthorizationHeader))

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -68,6 +68,21 @@ class SharedMiddlewareTransformersTests: SnapshotTestCase {
     assertSnapshot(matching: middleware(conn).perform(), as: .conn)
   }
 
+  func testBasicAuth_Authorized_LowercasedHeaderName() {
+    let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
+      basicAuth(user: "Hello", password: "World")
+        <| writeStatus(.ok)
+        >=> respond(html: "<p>Hello, world</p>")
+
+    let conn = connection(
+      from: URLRequest(url: URL(string: "/")!)
+        |> \.allHTTPHeaderFields .~ ["authorization": "Basic SGVsbG86V29ybGQ="],
+      defaultHeaders: []
+    )
+    
+    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+  }
+
   func testRedirectUnrelatedHosts() {
     let allowedHosts = [
       "www.pointfree.co",

--- a/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Authorized_LowercasedHeaderName.1.Conn.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Authorized_LowercasedHeaderName.1.Conn.txt
@@ -1,0 +1,8 @@
+GET /
+Authorization: Basic SGVsbG86V29ybGQ=
+
+200 OK
+Content-Length: 19
+Content-Type: text/html; charset=utf-8
+
+<p>Hello, world</p>

--- a/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Authorized_LowercasedHeaderName.1.Conn.txt
+++ b/Tests/HttpPipelineTests/__Snapshots__/SharedMiddlewareTransformersTests/testBasicAuth_Authorized_LowercasedHeaderName.1.Conn.txt
@@ -1,8 +1,0 @@
-GET /
-Authorization: Basic SGVsbG86V29ybGQ=
-
-200 OK
-Content-Length: 19
-Content-Type: text/html; charset=utf-8
-
-<p>Hello, world</p>

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -123,11 +123,11 @@ extension SharedMiddlewareTransformersTests {
     ("testBasicAuth_Unauthorized_Realm", testBasicAuth_Unauthorized_Realm),
     ("testBasicAuth_Unauthorized_CustomFailure", testBasicAuth_Unauthorized_CustomFailure),
     ("testBasicAuth_Authorized", testBasicAuth_Authorized),
-    ("testBasicAuth_Authorized_LowercasedHeaderName", testBasicAuth_Authorized_LowercasedHeaderName),
     ("testRedirectUnrelatedHosts", testRedirectUnrelatedHosts),
     ("testRequireHerokuHttps", testRequireHerokuHttps),
     ("testRequireHttps", testRequireHttps),
-    ("testRequestLogger", testRequestLogger)
+    ("testRequestLogger", testRequestLogger),
+    ("testBasiAuthValidationIsCaseInsensitive", testBasiAuthValidationIsCaseInsensitive)
   ]
 }
 extension SignedCookieTests {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.15.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest
@@ -123,6 +123,7 @@ extension SharedMiddlewareTransformersTests {
     ("testBasicAuth_Unauthorized_Realm", testBasicAuth_Unauthorized_Realm),
     ("testBasicAuth_Unauthorized_CustomFailure", testBasicAuth_Unauthorized_CustomFailure),
     ("testBasicAuth_Authorized", testBasicAuth_Authorized),
+    ("testBasicAuth_Authorized_LowercasedHeaderName", testBasicAuth_Authorized_LowercasedHeaderName),
     ("testRedirectUnrelatedHosts", testRedirectUnrelatedHosts),
     ("testRequireHerokuHttps", testRequireHerokuHttps),
     ("testRequireHttps", testRequireHttps),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -127,7 +127,7 @@ extension SharedMiddlewareTransformersTests {
     ("testRequireHerokuHttps", testRequireHerokuHttps),
     ("testRequireHttps", testRequireHttps),
     ("testRequestLogger", testRequestLogger),
-    ("testBasiAuthValidationIsCaseInsensitive", testBasiAuthValidationIsCaseInsensitive)
+    ("testBasicAuthValidationIsCaseInsensitive", testBasicAuthValidationIsCaseInsensitive)
   ]
 }
 extension SignedCookieTests {


### PR DESCRIPTION
sometimes authorization header on Linux is typed lowercased which cause basic authorization fails, this simple fix patch the problem 