### PR TITLE
Async-Await

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ on:
 jobs:
   build:
     name: MacOS
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_14.1.app
     - name: Run tests
       run: make test-swift
 
@@ -21,6 +23,6 @@ jobs:
     name: Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: make test-linux

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test-linux:
 		--rm \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.6 \
+		swift:5.7 \
 		bash -c 'apt-get update && apt-get -y install libssl-dev libz-dev make openssl && make test-swift'
 
 test-swift:

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-prelude",
       "state" : {
-        "branch" : "async",
-        "revision" : "864f841821594f3f33a66ad133bb14771c862a3b"
+        "branch" : "35ee343",
+        "revision" : "35ee343e31e0ae4ea349d3f556d55a5f4eaf4432"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a16e2f54a25b2af217044e5168997009a505930f",
-        "version" : "2.42.0"
+        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
+        "version" : "2.45.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/pointfreeco/swift-prelude",
       "state" : {
         "branch" : "async",
-        "revision" : "53574c16e0c97f9f23499630184b076bb216a4c4"
+        "revision" : "6ab33edb02a005e7cbe81ffb08f4d634010ee80f"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,88 +1,86 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "ee5880e031da4c609f372cf7472476ab51d5dd19",
-          "version": "1.0.200"
-        }
-      },
-      {
-        "package": "swift-atomics",
-        "repositoryURL": "https://github.com/apple/swift-atomics.git",
-        "state": {
-          "branch": null,
-          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-          "version": "1.0.3"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
-          "version": "1.1.7"
-        }
-      },
-      {
-        "package": "swift-html",
-        "repositoryURL": "https://github.com/pointfreeco/swift-html",
-        "state": {
-          "branch": "14d01d1",
-          "revision": "14d01d19e43598167a8f8965af478285835ca010",
-          "version": null
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "a16e2f54a25b2af217044e5168997009a505930f",
-          "version": "2.42.0"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "6c84d247754ad77487a6f0694273b89b83efd056",
-          "version": "1.14.0"
-        }
-      },
-      {
-        "package": "swift-prelude",
-        "repositoryURL": "https://github.com/pointfreeco/swift-prelude",
-        "state": {
-          "branch": "7ff9911",
-          "revision": "7ff9911580b2f9b7ead5375099781f28b8aad6a8",
-          "version": null
-        }
-      },
-      {
-        "package": "swift-snapshot-testing",
-        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing",
-        "state": {
-          "branch": null,
-          "revision": "f29e2014f6230cf7d5138fc899da51c7f513d467",
-          "version": "1.10.0"
-        }
+  "pins" : [
+    {
+      "identity" : "bluecryptor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IBM-Swift/BlueCryptor.git",
+      "state" : {
+        "revision" : "ee5880e031da4c609f372cf7472476ab51d5dd19",
+        "version" : "1.0.200"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-html",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-html",
+      "state" : {
+        "branch" : "14d01d1",
+        "revision" : "14d01d19e43598167a8f8965af478285835ca010"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "a16e2f54a25b2af217044e5168997009a505930f",
+        "version" : "2.42.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "6c84d247754ad77487a6f0694273b89b83efd056",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-prelude",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-prelude",
+      "state" : {
+        "branch" : "async",
+        "revision" : "53574c16e0c97f9f23499630184b076bb216a4c4"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "f29e2014f6230cf7d5138fc899da51c7f513d467",
+        "version" : "1.10.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/pointfreeco/swift-prelude",
       "state" : {
         "branch" : "async",
-        "revision" : "6ab33edb02a005e7cbe81ffb08f4d634010ee80f"
+        "revision" : "4dddfb1baa1f437cfdc43b0987ab1f73c8030d14"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/pointfreeco/swift-prelude",
       "state" : {
         "branch" : "async",
-        "revision" : "4dddfb1baa1f437cfdc43b0987ab1f73c8030d14"
+        "revision" : "864f841821594f3f33a66ad133bb14771c862a3b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
+
 import PackageDescription
 
 let package = Package(
@@ -27,17 +28,13 @@ let package = Package(
     .library(name: "View", targets: ["View"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-html", .revision("14d01d1")),
-    .package(url: "https://github.com/pointfreeco/swift-prelude", .revision("7ff9911")),
+    .package(url: "https://github.com/pointfreeco/swift-html", revision: "14d01d1"),
+    .package(url: "https://github.com/pointfreeco/swift-prelude", branch: "async"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.10.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
-    .package(
-      name: "Cryptor",
-      url: "https://github.com/IBM-Swift/BlueCryptor.git",
-      from: "1.0.0"
-    ),
+    .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
   ],
   targets: [
     .target(
@@ -163,7 +160,7 @@ let package = Package(
         .product(name: "NIOHTTP1", package: "swift-nio"),
         .product(name: "NIOHTTPCompression", package: "swift-nio-extras"),
         .product(name: "Crypto", package: "swift-crypto"),
-        .product(name: "Cryptor", package: "Cryptor"),
+        .product(name: "Cryptor", package: "BlueCryptor"),
         .product(name: "Html", package: "swift-html"),
         .product(name: "Optics", package: "swift-prelude"),
         .product(name: "Prelude", package: "swift-prelude"),

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-html", revision: "14d01d1"),
-    .package(url: "https://github.com/pointfreeco/swift-prelude", branch: "async"),
+    .package(url: "https://github.com/pointfreeco/swift-prelude", revision: "35ee343"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.10.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),

--- a/Sources/HttpPipeline/NIO.swift
+++ b/Sources/HttpPipeline/NIO.swift
@@ -95,7 +95,9 @@ private final class Handler: ChannelInboundHandler {
       }
 
       let promise = context.eventLoop.makePromise(of: Conn<ResponseEnded, Data>.self)
-      self.middleware(connection(from: req)).parallel.run(promise.succeed)
+      promise.completeWithTask {
+        await self.middleware(connection(from: req)).performAsync()
+      }
       _ = promise.futureResult.flatMap { conn -> EventLoopFuture<Void> in
         let res = conn.response
 

--- a/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
+++ b/Tests/HttpPipelineHtmlSupportTests/HttpPipelineHtmlSupportTests.swift
@@ -8,14 +8,15 @@ import Prelude
 import View
 import XCTest
 
+@MainActor
 class HttpPipelineHtmlSupportTests: XCTestCase {
-  func testResponse() {
+  func testResponse() async {
     let view = View<Prelude.Unit> { _ in .p(["Hello world!"]) }
     let pipeline = writeStatus(.ok)
       >=> respond(view)
 
     let conn = connection(from: URLRequest(url: URL(string: "/")!), defaultHeaders: [])
-    let response = (conn |> pipeline).perform()
+    let response = await (conn |> pipeline).performAsync()
 
     XCTAssertEqual(200, response.response.status.rawValue)
     XCTAssertEqual(

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -229,7 +229,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
     )
   }
   
-  func testBasicAuthValidationIsCaseInsensitive() {
+  func testBasicAuthValidationIsCaseInsensitive() async {  // NB: Must be `async` for Linux
     let urlRequestWithUppercaseAuthorizationHeader = URLRequest(url: URL(string: "/")!)
       |> \.allHTTPHeaderFields .~ ["Authorization": "Basic SGVsbG86V29ybGQ="]
     XCTAssertTrue(validateBasicAuth(user: "Hello", password: "World", request: urlRequestWithUppercaseAuthorizationHeader))

--- a/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
+++ b/Tests/HttpPipelineTests/SharedMiddlewareTransformersTests.swift
@@ -10,40 +10,44 @@ import XCTest
 
 private let conn = connection(from: URLRequest(url: URL(string: "/")!), defaultHeaders: [])
 
+@MainActor
 class SharedMiddlewareTransformersTests: XCTestCase {
   override func setUp() {
     super.setUp()
 //    record=true
   }
 
-  func testBasicAuth_Unauthorized() {
+  func testBasicAuth_Unauthorized() async {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World")
         <| writeStatus(.ok)
         >=> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testBasicAuth_Unauthorized_ProtectedPredicate() {
+  func testBasicAuth_Unauthorized_ProtectedPredicate() async {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World", protect: const(false))
         <| writeStatus(.ok)
         >=> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testBasicAuth_Unauthorized_Realm() {
+  func testBasicAuth_Unauthorized_Realm() async {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World", realm: "Point-Free")
         <| writeStatus(.ok)
         >=> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testBasicAuth_Unauthorized_CustomFailure() {
+  func testBasicAuth_Unauthorized_CustomFailure() async {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(
         user: "Hello",
@@ -53,10 +57,11 @@ class SharedMiddlewareTransformersTests: XCTestCase {
         <| writeStatus(.ok)
         >=> respond(html: "<p>Hello, world</p>")
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testBasicAuth_Authorized() {
+  func testBasicAuth_Authorized() async {
     let middleware: Middleware<StatusLineOpen, ResponseEnded, Prelude.Unit, Data> =
       basicAuth(user: "Hello", password: "World")
         <| writeStatus(.ok)
@@ -68,10 +73,11 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       defaultHeaders: []
     )
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testRedirectUnrelatedHosts() {
+  func testRedirectUnrelatedHosts() async {
     let allowedHosts = [
       "www.pointfree.co",
       "127.0.0.1",
@@ -88,25 +94,36 @@ class SharedMiddlewareTransformersTests: XCTestCase {
         >=> send(Data("<p>Hello, world</p>".utf8))
         >=> end
 
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    var response = await middleware(
+      connection(
+        from: URLRequest(url: URL(string: "http://www.pointfree.co")!), defaultHeaders: []
+      )
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://pointfree.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(from: URLRequest(url: URL(string: "http://pointfree.co")!), defaultHeaders: [])
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.point-free.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(
+        from: URLRequest(url: URL(string: "http://www.point-free.co")!), defaultHeaders: []
+      )
     )
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testRequireHerokuHttps() {
+  func testRequireHerokuHttps() async {
     let allowedInsecureHosts = [
       "127.0.0.1",
       "localhost",
@@ -129,21 +146,27 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       return connection(from: result, defaultHeaders: [])
     }
 
-    assertSnapshot(
-      matching: middleware(securedConnection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!))).perform(),
-      as: .conn
+    var response = await middleware(
+      securedConnection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!))
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(
+        from: URLRequest(url: URL(string: "https://www.pointfree.co")!), defaultHeaders: [])
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])
     )
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testRequireHttps() {
+  func testRequireHttps() async {
     let allowedInsecureHosts = [
       "127.0.0.1",
       "localhost",
@@ -159,21 +182,30 @@ class SharedMiddlewareTransformersTests: XCTestCase {
         >=> send(Data("<p>Hello, world</p>".utf8))
         >=> end
 
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "https://www.pointfree.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    var response = await middleware(
+      connection(
+        from: URLRequest(url: URL(string: "https://www.pointfree.co")!), defaultHeaders: []
+      )
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://www.pointfree.co")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(
+        from: URLRequest(url: URL(string: "http://www.pointfree.co")!), defaultHeaders: []
+      )
     )
-    assertSnapshot(
-      matching: middleware(connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])).perform(),
-      as: .conn
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
+
+    response = await middleware(
+      connection(from: URLRequest(url: URL(string: "http://0.0.0.0:8080")!), defaultHeaders: [])
     )
+    .performAsync()
+    assertSnapshot(matching: response, as: .conn)
   }
 
-  func testRequestLogger() {
+  func testRequestLogger() async {
     var log: [String] = []
     let uuid = UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFDEAD")!
     let middleware = requestLogger(logger: { log.append($0) }, uuid: { uuid })
@@ -181,7 +213,7 @@ class SharedMiddlewareTransformersTests: XCTestCase {
       >=> writeHeader(.contentType(.html))
       >=> respond(html: "<p>Hello, world</p>")
 
-    _ = middleware(conn).perform()
+    _ = await middleware(conn).performAsync()
 
     XCTAssertEqual(2, log.count)
     XCTAssertEqual("DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFDEAD [Request] GET /", log[0])

--- a/Tests/HttpPipelineTests/SignedCookieTests.swift
+++ b/Tests/HttpPipelineTests/SignedCookieTests.swift
@@ -11,13 +11,14 @@ import Crypto
 
 private let conn = connection(from: URLRequest(url: URL(string: "/")!), defaultHeaders: [])
 
+@MainActor
 class SignedCookieTests: XCTestCase {
   override func setUp() {
     super.setUp()
 //    isRecording=true
   }
 
-  func testSignedCookie() {
+  func testSignedCookie() async {
     let secret = "cce35c66b1c158d0fdbe93284ab0d2e2003daa0033c4d49753ea8147bdb5a29e30b35d46d5bbad89a6916b9a"
     let signedCookieValue = """
 aGVsbG8td29ybGQ=\
@@ -33,7 +34,8 @@ aGVsbG8td29ybGQ=\
         )
         >=> end
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
 
     XCTAssertEqual(
       "hello-world",
@@ -48,7 +50,7 @@ aGVsbG8td29ybGQ=\
     )
   }
 
-  func testSignedCookie_EncodableValue() {
+  func testSignedCookie_EncodableValue() async {
     let secret = "cce35c66b1c158d0fdbe93284ab0d2e2003daa0033c4d49753ea8147bdb5a29e30b35d46d5bbad89a6916b9a"
     let episode = Episode(id: 42, name: "All About Functions")
     let signedCookieValue = """
@@ -66,7 +68,8 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
         >=> end
 
     #if !os(Linux)
-      assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+      let response = await middleware(conn).performAsync()
+      assertSnapshot(matching: response, as: .conn)
     #endif
 
     XCTAssertEqual(
@@ -82,7 +85,7 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
     )
   }
 
-  func testEncryptedCookie() {
+  func testEncryptedCookie() async {
     let secret = "deadbeefdeadbeefdeadbeefdeadbeef"
     let encryptedCookieValue = """
 42486a73fb0573701336550a1bb0e96d\
@@ -99,7 +102,8 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
         )
         >=> end
 
-    assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+    let response = await middleware(conn).performAsync()
+    assertSnapshot(matching: response, as: .conn)
 
     XCTAssertEqual(
       "hello-world",
@@ -117,7 +121,7 @@ eyJpZCI6NDIsIm5hbWUiOiJBbGwgQWJvdXQgRnVuY3Rpb25zIn0=\
     )
   }
 
-  func testEncryptedCookie_EncodableValue() {
+  func testEncryptedCookie_EncodableValue() async {
     let secret = "deadbeefdeadbeefdeadbeefdeadbeef"
     let encryptedCookieValue = """
 674d4b73680a254d2b881823a221ac05\
@@ -139,7 +143,8 @@ cb4db8ac9390ac810837809f11bc6803\
         >=> end
 
     #if !os(Linux)
-      assertSnapshot(matching: middleware(conn).perform(), as: .conn)
+      let response = await middleware(conn).performAsync()
+      assertSnapshot(matching: response, as: .conn)
     #endif
 
     XCTAssertEqual(


### PR DESCRIPTION
This PR updates swift-web to interact with `IO` in an asynchronous way. Surprisingly, only tests were calling `perform` directly, and `Parallel.run` is now async-safe on the `async` branch.